### PR TITLE
feat: add context selector with subscription validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,34 @@ flutter test
 | GET | `/v1/estado-suscripcion` | Verificación de suscripción |
 | GET | `/v1/tenancy/context` | Contexto de locales (opcional) |
 
+## Frontend / Selector de Empresa/Local
+
+Pantalla responsive para elegir el local de trabajo.
+
+### Flujo de datos
+
+1. Se consulta `GET /v1/tenancy/context` para obtener empresa, locales y estado de suscripción.
+2. Si no se reciben locales se usa `GET /v1/locales?mine=1`.
+3. Al seleccionar un local se valida su suscripción con `GET /v1/estado-suscripcion?local_id=<id>`
+   (o sin parámetro si el backend no lo soporta).
+4. Cuando la suscripción está vigente se guarda `local_id` y `empresa_id` en el `ContextController`,
+   se persiste el `local_id` opcionalmente y se configura el header `X-Local-Id` para todas las
+   peticiones posteriores.
+5. Navegación a `/dashboard`. Si la suscripción no está activa se redirige a `/subscription/blocked`.
+
+### Responsive
+
+El listado usa un `GridView` adaptable (`SliverGridDelegateWithMaxCrossAxisExtent`) que muestra una columna en móviles y varias
+columnas en pantallas anchas.
+
+### Endpoints usados
+
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| GET | `/v1/tenancy/context` | Obtiene empresa y locales del usuario |
+| GET | `/v1/locales?mine=1` | Fallback de locales del usuario |
+| GET | `/v1/estado-suscripcion?local_id=…` | Valida suscripción para el local |
+
 
 ## Arquitectura Frontend
 

--- a/api_registry.json
+++ b/api_registry.json
@@ -1,0 +1,5 @@
+[
+  {"method":"GET","path":"/v1/tenancy/context","name":"Contexto tenancy","module":"tenancy","permission":"tenancy.context.ver"},
+  {"method":"GET","path":"/v1/locales","name":"Listar locales del usuario (mine=1)","module":"locales","permission":"locales.ver"},
+  {"method":"GET","path":"/v1/estado-suscripcion","name":"Estado de suscripción (por empresa/local)","module":"suscripciones","permission":"suscripciones.ver"}
+]

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../env/env.dart';
 import '../../data/auth/auth_repository.dart';
 import '../../data/subscription/subscription_repository.dart';
+import '../../features/context/controllers/context_controller.dart';
 
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio(BaseOptions(baseUrl: Env.baseUrl));
@@ -15,6 +16,11 @@ final dioProvider = Provider<Dio>((ref) {
       final token = await authRepo.getToken();
       if (token != null) {
         options.headers['Authorization'] = 'Bearer $token';
+      }
+      final ctx = ref.read(contextControllerProvider);
+      final localId = ctx.localId;
+      if (localId != null) {
+        options.headers['X-Local-Id'] = localId.toString();
       }
       handler.next(options);
     },

--- a/lib/features/context/controllers/context_controller.dart
+++ b/lib/features/context/controllers/context_controller.dart
@@ -1,0 +1,110 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../core/routing/app_router.dart';
+import '../data/context_repository.dart';
+import '../data/local.dart';
+import '../data/subscription_status.dart';
+
+class ContextState {
+  const ContextState({
+    this.empresaId,
+    this.localId,
+    this.locales = const [],
+    this.isLoading = false,
+    this.error,
+  });
+
+  final int? empresaId;
+  final int? localId;
+  final List<Local> locales;
+  final bool isLoading;
+  final String? error;
+
+  ContextState copyWith({
+    int? empresaId,
+    int? localId,
+    List<Local>? locales,
+    bool? isLoading,
+    String? error,
+  }) =>
+      ContextState(
+        empresaId: empresaId ?? this.empresaId,
+        localId: localId ?? this.localId,
+        locales: locales ?? this.locales,
+        isLoading: isLoading ?? this.isLoading,
+        error: error,
+      );
+}
+
+final contextControllerProvider =
+    StateNotifierProvider<ContextController, ContextState>((ref) {
+  return ContextController(ref);
+});
+
+class ContextController extends StateNotifier<ContextState> {
+  ContextController(this._ref) : super(const ContextState());
+
+  final Ref _ref;
+
+  Future<void> loadContext() async {
+    if (state.isLoading) return;
+    state = state.copyWith(isLoading: true, error: null);
+    final repo = _ref.read(contextRepositoryProvider);
+    try {
+      final ctx = await repo.fetchTenancyContext();
+      if (ctx != null) {
+        state = state.copyWith(
+          empresaId: ctx.empresaId,
+          locales: ctx.locales,
+        );
+        if (ctx.suscripcionEstado != 'active') {
+          _ref.read(routerProvider).go('/subscription/blocked');
+          return;
+        }
+      } else {
+        final locales = await repo.fetchUserLocales();
+        state = state.copyWith(locales: locales);
+      }
+      if (state.locales.length == 1) {
+        await selectLocal(state.locales.first.id);
+      }
+    } catch (_) {
+      state = state.copyWith(error: 'Error al cargar');
+    } finally {
+      state = state.copyWith(isLoading: false);
+    }
+  }
+
+  Future<void> selectLocal(int localId) async {
+    final local = state.locales.firstWhere(
+      (l) => l.id == localId,
+      orElse: () => throw Exception('Local no permitido'),
+    );
+    try {
+      final status = await _ref
+          .read(contextRepositoryProvider)
+          .checkSubscription(localId: localId);
+      if (!status.vigente) {
+        _ref.read(routerProvider).go('/subscription/blocked');
+        return;
+      }
+      setHeaderXLocalId(localId);
+      state = state.copyWith(localId: localId, empresaId: local.empresaId);
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt('currentLocalId', localId);
+      _ref.read(routerProvider).go('/dashboard');
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 403) {
+        _ref.read(routerProvider).go('/subscription/blocked');
+      } else {
+        state = state.copyWith(error: 'Error al seleccionar local');
+      }
+    }
+  }
+
+  void setHeaderXLocalId(int? localId) {
+    state = state.copyWith(localId: localId);
+  }
+}

--- a/lib/features/context/data/context_repository.dart
+++ b/lib/features/context/data/context_repository.dart
@@ -1,0 +1,49 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/network/dio_client.dart';
+import 'tenancy_context.dart';
+import 'local.dart';
+import 'subscription_status.dart';
+
+final contextRepositoryProvider = Provider<ContextRepository>((ref) {
+  final dio = ref.read(dioProvider);
+  return ContextRepository(dio);
+});
+
+class ContextRepository {
+  ContextRepository(this._dio);
+
+  final Dio _dio;
+
+  Future<TenancyContext?> fetchTenancyContext() async {
+    final resp = await _dio.get('/v1/tenancy/context');
+    if (resp.statusCode == 200) {
+      return TenancyContext.fromJson(resp.data as Map<String, dynamic>);
+    }
+    return null;
+  }
+
+  Future<List<Local>> fetchUserLocales() async {
+    final resp = await _dio.get('/v1/locales', queryParameters: {'mine': 1});
+    if (resp.statusCode == 200) {
+      final data = resp.data['data'] as List<dynamic>;
+      return data.map((e) => Local.fromJson(e as Map<String, dynamic>)).toList();
+    }
+    return [];
+  }
+
+  Future<SubscriptionStatus> checkSubscription({int? localId}) async {
+    try {
+      final resp = await _dio.get('/v1/estado-suscripcion',
+          queryParameters: localId != null ? {'local_id': localId} : null);
+      return SubscriptionStatus.fromJson(resp.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 400 || e.response?.statusCode == 404) {
+        final resp = await _dio.get('/v1/estado-suscripcion');
+        return SubscriptionStatus.fromJson(resp.data as Map<String, dynamic>);
+      }
+      rethrow;
+    }
+  }
+}

--- a/lib/features/context/data/local.dart
+++ b/lib/features/context/data/local.dart
@@ -1,0 +1,19 @@
+class Local {
+  const Local({required this.id, required this.nombre, required this.empresaId});
+
+  final int id;
+  final String nombre;
+  final int empresaId;
+
+  factory Local.fromJson(Map<String, dynamic> json) => Local(
+        id: json['id'] as int,
+        nombre: json['nombre'] as String,
+        empresaId: json['empresa_id'] as int? ?? json['empresaId'] as int? ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'nombre': nombre,
+        'empresa_id': empresaId,
+      };
+}

--- a/lib/features/context/data/subscription_status.dart
+++ b/lib/features/context/data/subscription_status.dart
@@ -1,0 +1,23 @@
+class SubscriptionStatus {
+  const SubscriptionStatus({required this.vigente, this.estado, this.fechaFin});
+
+  final bool vigente;
+  final String? estado;
+  final String? fechaFin;
+
+  factory SubscriptionStatus.fromJson(Map<String, dynamic> json) {
+    if (json.containsKey('vigente')) {
+      return SubscriptionStatus(
+        vigente: json['vigente'] as bool,
+        estado: json['estado'] as String?,
+        fechaFin: json['fecha_fin'] as String? ?? json['next_renewal_at'] as String?,
+      );
+    }
+    final estado = json['estado'] as String?;
+    return SubscriptionStatus(
+      vigente: estado == 'active',
+      estado: estado,
+      fechaFin: json['next_renewal_at'] as String?,
+    );
+  }
+}

--- a/lib/features/context/data/tenancy_context.dart
+++ b/lib/features/context/data/tenancy_context.dart
@@ -1,0 +1,32 @@
+import 'local.dart';
+
+class TenancyContext {
+  const TenancyContext({
+    required this.empresaId,
+    required this.empresaNombre,
+    required this.suscripcionEstado,
+    required this.locales,
+  });
+
+  final int empresaId;
+  final String empresaNombre;
+  final String suscripcionEstado;
+  final List<Local> locales;
+
+  factory TenancyContext.fromJson(Map<String, dynamic> json) {
+    final empresaId = json['empresa_id'] as int;
+    final localesJson = json['locales'] as List<dynamic>? ?? [];
+    final locales = localesJson
+        .map((e) => Local.fromJson({
+              ...e as Map<String, dynamic>,
+              'empresa_id': empresaId,
+            }))
+        .toList();
+    return TenancyContext(
+      empresaId: empresaId,
+      empresaNombre: json['empresa_nombre'] as String,
+      suscripcionEstado: json['suscripcion_estado'] as String,
+      locales: locales,
+    );
+  }
+}

--- a/lib/features/context/ui/context_selector_page.dart
+++ b/lib/features/context/ui/context_selector_page.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_spacing.dart';
+import '../../../core/theme/app_radius.dart';
+import '../controllers/context_controller.dart';
+import '../data/local.dart';
+
+class ContextSelectorPage extends HookConsumerWidget {
+  const ContextSelectorPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final radius = Theme.of(context).extension<AppRadius>()!;
+    final colors = Theme.of(context).extension<AppColors>()!;
+    final controller = ref.read(contextControllerProvider.notifier);
+    final state = ref.watch(contextControllerProvider);
+
+    useEffect(() {
+      controller.loadContext();
+      return null;
+    }, const []);
+
+    Widget body;
+    if (state.isLoading) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (state.error != null) {
+      body = Center(child: Text(state.error!));
+    } else if (state.locales.isEmpty) {
+      body = Center(child: Text('No tienes locales asignados'));
+    } else {
+      body = LayoutBuilder(
+        builder: (context, constraints) {
+          return GridView.builder(
+            padding: EdgeInsets.all(spacing.md),
+            gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 420,
+              mainAxisSpacing: spacing.md,
+              crossAxisSpacing: spacing.md,
+              childAspectRatio: 3,
+            ),
+            itemCount: state.locales.length,
+            itemBuilder: (context, index) {
+              final local = state.locales[index];
+              return _LocalCard(
+                local: local,
+                onTap: () => controller.selectLocal(local.id),
+                spacing: spacing,
+                radius: radius,
+                colors: colors,
+              );
+            },
+          );
+        },
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Selecciona tu local')),
+      body: body,
+    );
+  }
+}
+
+class _LocalCard extends StatelessWidget {
+  const _LocalCard({
+    required this.local,
+    required this.onTap,
+    required this.spacing,
+    required this.radius,
+    required this.colors,
+  });
+
+  final Local local;
+  final VoidCallback onTap;
+  final AppSpacing spacing;
+  final AppRadius radius;
+  final AppColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: Key('local-${local.id}'),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(radius.md),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(radius.md),
+        child: Padding(
+          padding: EdgeInsets.all(spacing.md),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(local.nombre,
+                  style: Theme.of(context).textTheme.titleMedium),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/context_controller_test.dart
+++ b/test/context_controller_test.dart
@@ -1,0 +1,55 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:punto_venta_front/features/context/controllers/context_controller.dart';
+import 'package:punto_venta_front/features/context/data/context_repository.dart';
+import 'package:punto_venta_front/features/context/data/local.dart';
+import 'package:punto_venta_front/features/context/data/subscription_status.dart';
+import 'package:punto_venta_front/core/network/dio_client.dart';
+import 'package:punto_venta_front/core/routing/app_router.dart';
+
+class FakeContextRepository extends Mock implements ContextRepository {}
+
+class FakeGoRouter extends Mock implements GoRouter {}
+
+class TestAdapter extends HttpClientAdapter {
+  RequestOptions? options;
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, Stream<List<int>>? requestStream,
+      Future? cancelFuture) async {
+    this.options = options;
+    return ResponseBody.fromString('', 200, headers: {}, statusCode: 200);
+  }
+}
+
+void main() {
+  test('selectLocal sets X-Local-Id header', () async {
+    SharedPreferences.setMockInitialValues({});
+    final repo = FakeContextRepository();
+    when(() => repo.checkSubscription(localId: any(named: 'localId')))
+        .thenAnswer((_) async => const SubscriptionStatus(vigente: true));
+    final router = FakeGoRouter();
+    final container = ProviderContainer(overrides: [
+      contextRepositoryProvider.overrideWithValue(repo),
+      routerProvider.overrideWithValue(router),
+    ]);
+    final controller = container.read(contextControllerProvider.notifier);
+    controller.state = controller.state.copyWith(
+        locales: [const Local(id: 1, nombre: 'A', empresaId: 1)]);
+    final dio = container.read(dioProvider);
+    final adapter = TestAdapter();
+    dio.httpClientAdapter = adapter;
+
+    await controller.selectLocal(1);
+    await dio.get('/demo');
+
+    expect(adapter.options!.headers['X-Local-Id'], '1');
+  });
+}

--- a/test/context_repository_test.dart
+++ b/test/context_repository_test.dart
@@ -1,0 +1,65 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:punto_venta_front/features/context/data/context_repository.dart';
+
+class MockDio extends Mock implements Dio {}
+
+void main() {
+  test('fetchTenancyContext parses locales', () async {
+    final dio = MockDio();
+    when(() => dio.get('/v1/tenancy/context')).thenAnswer((_) async => Response(
+          requestOptions: RequestOptions(path: '/v1/tenancy/context'),
+          statusCode: 200,
+          data: {
+            'empresa_id': 1,
+            'empresa_nombre': 'ACME',
+            'suscripcion_estado': 'active',
+            'locales': [
+              {'id': 10, 'nombre': 'Matriz'}
+            ],
+          },
+        ));
+    final repo = ContextRepository(dio);
+    final ctx = await repo.fetchTenancyContext();
+    expect(ctx!.locales.first.id, 10);
+    expect(ctx.locales.first.empresaId, 1);
+  });
+
+  test('checkSubscription interprets extended format', () async {
+    final dio = MockDio();
+    when(() => dio.get('/v1/estado-suscripcion',
+            queryParameters: {'local_id': 10})).thenAnswer((_) async => Response(
+          requestOptions: RequestOptions(path: '/v1/estado-suscripcion'),
+          statusCode: 200,
+          data: {
+            'estado': 'active',
+            'plan': {'codigo': 'pro'},
+            'next_renewal_at': '2025-09-18'
+          },
+        ));
+    final repo = ContextRepository(dio);
+    final status = await repo.checkSubscription(localId: 10);
+    expect(status.vigente, true);
+    expect(status.fechaFin, '2025-09-18');
+  });
+
+  test('checkSubscription interprets direct format', () async {
+    final dio = MockDio();
+    when(() => dio.get('/v1/estado-suscripcion',
+            queryParameters: {'local_id': 10})).thenAnswer((_) async => Response(
+          requestOptions: RequestOptions(path: '/v1/estado-suscripcion'),
+          statusCode: 200,
+          data: {
+            'estado': 'active',
+            'vigente': true,
+            'fecha_fin': '2025-09-18'
+          },
+        ));
+    final repo = ContextRepository(dio);
+    final status = await repo.checkSubscription(localId: 10);
+    expect(status.vigente, true);
+    expect(status.fechaFin, '2025-09-18');
+  });
+}

--- a/test/context_selector_page_test.dart
+++ b/test/context_selector_page_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:punto_venta_front/features/context/controllers/context_controller.dart';
+import 'package:punto_venta_front/features/context/ui/context_selector_page.dart';
+import 'package:punto_venta_front/features/context/data/local.dart';
+
+class DummyController extends ContextController {
+  DummyController(Ref ref, ContextState initial) : super(ref) {
+    state = initial;
+  }
+
+  @override
+  Future<void> loadContext() async {}
+
+  @override
+  Future<void> selectLocal(int localId) async {}
+}
+
+void main() {
+  testWidgets('grid adapts to narrow width', (tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(360, 800);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+    addTearDown(tester.binding.window.clearDevicePixelRatioTestValue);
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        contextControllerProvider.overrideWith((ref) => DummyController(
+            ref,
+            const ContextState(locales: [
+              Local(id: 1, nombre: 'A', empresaId: 1),
+              Local(id: 2, nombre: 'B', empresaId: 1)
+            ]))),
+      child: const MaterialApp(home: ContextSelectorPage()),
+    ));
+    await tester.pumpAndSettle();
+    final first = tester.getTopLeft(find.byKey(const Key('local-1')));
+    final second = tester.getTopLeft(find.byKey(const Key('local-2')));
+    expect(second.dy, greaterThan(first.dy));
+  });
+
+  testWidgets('grid adapts to wide width', (tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(1024, 800);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+    addTearDown(tester.binding.window.clearDevicePixelRatioTestValue);
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        contextControllerProvider.overrideWith((ref) => DummyController(
+            ref,
+            const ContextState(locales: [
+              Local(id: 1, nombre: 'A', empresaId: 1),
+              Local(id: 2, nombre: 'B', empresaId: 1)
+            ]))),
+      child: const MaterialApp(home: ContextSelectorPage()),
+    ));
+    await tester.pumpAndSettle();
+    final first = tester.getTopLeft(find.byKey(const Key('local-1')));
+    final second = tester.getTopLeft(find.byKey(const Key('local-2')));
+    expect(second.dy, equals(first.dy));
+  });
+}


### PR DESCRIPTION
## Summary
- implement context selector page with responsive grid
- manage tenancy context and local subscription status
- send X-Local-Id header on authenticated requests
- document endpoints and update API registry

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ab2a4ee0832f92ea65db6113c393