### PR TITLE
feat: add recipe editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,36 @@ Módulo para administrar productos del punto de venta.
 3. Crear, editar, activar/desactivar y eliminar un producto.
 4. Usar el campo de búsqueda para filtrar por nombre o código.
 
+## Frontend / Receta/BOM del producto
+
+Pantalla para gestionar los insumos de un producto. Permite ver, añadir, editar y eliminar líneas de receta.
+
+### Flujo de trabajo
+
+1. Al cargar la pantalla se consulta `GET /v1/productos/{id}/receta`.
+2. "Añadir insumo" abre un diálogo con búsqueda de insumos (`GET /v1/productos?tipo=insumo&search=`) y campos `Cantidad` y `Merma %`.
+3. Se validan `cantidad > 0`, `merma %` entre 0 y 100 y se bloquean duplicados de insumo.
+4. Guardar envía `POST /v1/productos/{id}/receta` con la lista completa.
+5. Eliminar línea ejecuta `DELETE /v1/productos/{id}/receta/{insumo_id}`.
+
+### Endpoints usados
+
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| GET | `/v1/productos/{id}/receta` | Obtener receta del producto |
+| POST | `/v1/productos/{id}/receta` | Guardar receta completa |
+| DELETE | `/v1/productos/{id}/receta/{insumo_id}` | Eliminar línea específica |
+| GET | `/v1/productos?tipo=insumo&search=` | Buscar insumos para autocomplete |
+| GET | `/v1/unidades?activo=true` | Listar unidades disponibles |
+
+### Validaciones
+
+- `cantidad` debe ser mayor a 0.
+- `merma %` entre 0 y 100.
+- No se permiten insumos duplicados.
+
+La interfaz es responsive y reutiliza los tokens de tema (`AppColors`, `AppSpacing`, `AppRadius`).
+
 ## Arquitectura Frontend
 
 - **Estado**: Riverpod (`hooks_riverpod`).

--- a/api_registry.json
+++ b/api_registry.json
@@ -24,5 +24,10 @@
   {"method":"POST","path":"/v1/productos","name":"Crear producto","module":"productos","permission":"productos.crear"},
   {"method":"PUT","path":"/v1/productos/{id}","name":"Editar producto","module":"productos","permission":"productos.editar"},
   {"method":"DELETE","path":"/v1/productos/{id}","name":"Eliminar producto","module":"productos","permission":"productos.eliminar"},
-  {"method":"POST","path":"/v1/productos/import","name":"Importar productos","module":"productos","permission":"productos.import"}
+  {"method":"POST","path":"/v1/productos/import","name":"Importar productos","module":"productos","permission":"productos.import"},
+  {"method":"GET","path":"/v1/productos/{id}/receta","name":"Obtener receta de producto","module":"productos","permission":"productos.recetas.ver"},
+  {"method":"POST","path":"/v1/productos/{id}/receta","name":"Guardar receta de producto","module":"productos","permission":"productos.recetas.editar"},
+  {"method":"DELETE","path":"/v1/productos/{id}/receta/{insumo_id}","name":"Eliminar línea de receta","module":"productos","permission":"productos.recetas.editar"},
+  {"method":"GET","path":"/v1/productos","name":"Buscar insumos (tipo=insumo)","module":"productos","permission":"productos.ver"},
+  {"method":"GET","path":"/v1/unidades","name":"Listar unidades (vista)","module":"unidades","permission":"unidades.ver"}
 ]

--- a/lib/features/products/data/products_repository.dart
+++ b/lib/features/products/data/products_repository.dart
@@ -50,4 +50,21 @@ class ProductsRepository {
   Future<void> importFile(Map<String, dynamic> dto) async {
     await _dio.post('/v1/productos/import', data: dto);
   }
+
+  Future<List<Product>> searchInsumos(String query) async {
+    final resp = await _dio.get(
+      '/v1/productos',
+      queryParameters: {'tipo': 'insumo', 'search': query},
+    );
+    final data = resp.data;
+    if (data is List) {
+      return data
+          .map((e) => Product.fromJson(Map<String, dynamic>.from(e)))
+          .toList();
+    }
+    final list = data['data'] as List<dynamic>;
+    return list
+        .map((e) => Product.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
 }

--- a/lib/features/recipe/controllers/recipe_controller.dart
+++ b/lib/features/recipe/controllers/recipe_controller.dart
@@ -1,0 +1,65 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../data/models/recipe_line.dart';
+import '../data/recipe_repository.dart';
+import 'recipe_state.dart';
+
+final recipeControllerProvider =
+    StateNotifierProvider<RecipeController, RecipeState>((ref) {
+  return RecipeController(ref);
+});
+
+class RecipeController extends StateNotifier<RecipeState> {
+  RecipeController(this._ref) : super(const RecipeState());
+
+  final Ref _ref;
+
+  Future<void> load(int productId) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final repo = _ref.read(recipeRepositoryProvider);
+      final lines = await repo.getRecipe(productId);
+      state = state.copyWith(lines: lines);
+    } catch (_) {
+      state = state.copyWith(error: 'No se pudo cargar');
+    } finally {
+      state = state.copyWith(isLoading: false);
+    }
+  }
+
+  Future<String?> addLine(RecipeLine line) async {
+    if (state.lines.any((l) => l.insumoId == line.insumoId)) {
+      return 'Este insumo ya está en la receta';
+    }
+    state = state.copyWith(lines: [...state.lines, line], dirty: true);
+    return null;
+  }
+
+  void updateLine(RecipeLine line) {
+    final idx = state.lines.indexWhere((l) => l.insumoId == line.insumoId);
+    if (idx == -1) return;
+    final list = [...state.lines];
+    list[idx] = line;
+    state = state.copyWith(lines: list, dirty: true);
+  }
+
+  Future<void> removeLine(int insumoId) async {
+    state = state.copyWith(
+      lines: state.lines.where((l) => l.insumoId != insumoId).toList(),
+      dirty: true,
+    );
+  }
+
+  Future<void> saveAll(int productId) async {
+    final repo = _ref.read(recipeRepositoryProvider);
+    final lines = await repo.saveRecipe(productId, state.lines);
+    state = state.copyWith(lines: lines, dirty: false);
+  }
+
+  Future<void> deleteLine(int productId, int insumoId) async {
+    final repo = _ref.read(recipeRepositoryProvider);
+    await repo.deleteLine(productId, insumoId);
+    state = state.copyWith(
+        lines: state.lines.where((l) => l.insumoId != insumoId).toList());
+  }
+}

--- a/lib/features/recipe/controllers/recipe_state.dart
+++ b/lib/features/recipe/controllers/recipe_state.dart
@@ -1,0 +1,27 @@
+import '../data/models/recipe_line.dart';
+
+class RecipeState {
+  const RecipeState({
+    this.lines = const [],
+    this.isLoading = false,
+    this.error,
+    this.dirty = false,
+  });
+
+  final List<RecipeLine> lines;
+  final bool isLoading;
+  final String? error;
+  final bool dirty;
+
+  RecipeState copyWith({
+    List<RecipeLine>? lines,
+    bool? isLoading,
+    String? error,
+    bool? dirty,
+  }) => RecipeState(
+        lines: lines ?? this.lines,
+        isLoading: isLoading ?? this.isLoading,
+        error: error,
+        dirty: dirty ?? this.dirty,
+      );
+}

--- a/lib/features/recipe/data/models/recipe_line.dart
+++ b/lib/features/recipe/data/models/recipe_line.dart
@@ -1,0 +1,65 @@
+class RecipeLine {
+  RecipeLine({
+    required this.insumoId,
+    this.insumoCodigo,
+    this.insumoNombre,
+    this.unidadId,
+    this.unidadCodigo,
+    required this.cantidad,
+    required this.mermaPorcentaje,
+  });
+
+  final int insumoId;
+  final String? insumoCodigo;
+  final String? insumoNombre;
+  final int? unidadId;
+  final String? unidadCodigo;
+  final double cantidad;
+  final double mermaPorcentaje;
+
+  factory RecipeLine.fromJson(Map<String, dynamic> json) => RecipeLine(
+        insumoId: json['insumo_id'] as int,
+        insumoCodigo: json['insumo_codigo'] as String?,
+        insumoNombre: json['insumo_nombre'] as String?,
+        unidadId: json['unidad_id'] as int?,
+        unidadCodigo: json['unidad_codigo'] as String?,
+        cantidad: (json['cantidad'] as num).toDouble(),
+        mermaPorcentaje: (json['merma_porcentaje'] as num).toDouble(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'insumo_id': insumoId,
+        'insumo_codigo': insumoCodigo,
+        'insumo_nombre': insumoNombre,
+        'unidad_id': unidadId,
+        'unidad_codigo': unidadCodigo,
+        'cantidad': cantidad,
+        'merma_porcentaje': mermaPorcentaje,
+      };
+
+  RecipeLine copyWith({
+    int? insumoId,
+    String? insumoCodigo,
+    String? insumoNombre,
+    int? unidadId,
+    String? unidadCodigo,
+    double? cantidad,
+    double? mermaPorcentaje,
+  }) {
+    return RecipeLine(
+      insumoId: insumoId ?? this.insumoId,
+      insumoCodigo: insumoCodigo ?? this.insumoCodigo,
+      insumoNombre: insumoNombre ?? this.insumoNombre,
+      unidadId: unidadId ?? this.unidadId,
+      unidadCodigo: unidadCodigo ?? this.unidadCodigo,
+      cantidad: cantidad ?? this.cantidad,
+      mermaPorcentaje: mermaPorcentaje ?? this.mermaPorcentaje,
+    );
+  }
+
+  Map<String, dynamic> toPayload() => {
+        'insumo_id': insumoId,
+        'cantidad': cantidad,
+        'merma_porcentaje': mermaPorcentaje,
+      };
+}

--- a/lib/features/recipe/data/recipe_repository.dart
+++ b/lib/features/recipe/data/recipe_repository.dart
@@ -1,0 +1,41 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/network/dio_client.dart';
+import 'models/recipe_line.dart';
+
+final recipeRepositoryProvider = Provider<RecipeRepository>((ref) {
+  final dio = ref.read(dioProvider);
+  return RecipeRepository(dio);
+});
+
+class RecipeRepository {
+  RecipeRepository(this._dio);
+
+  final Dio _dio;
+
+  Future<List<RecipeLine>> getRecipe(int productId) async {
+    final resp = await _dio.get('/v1/productos/$productId/receta');
+    final list = resp.data['data'] as List<dynamic>;
+    return list
+        .map((e) => RecipeLine.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
+  Future<List<RecipeLine>> saveRecipe(
+      int productId, List<RecipeLine> lines) async {
+    final payload = lines.map((e) => e.toPayload()).toList();
+    final resp = await _dio.post(
+      '/v1/productos/$productId/receta',
+      data: payload,
+    );
+    final list = resp.data['data'] as List<dynamic>;
+    return list
+        .map((e) => RecipeLine.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
+  Future<void> deleteLine(int productId, int insumoId) async {
+    await _dio.delete('/v1/productos/$productId/receta/$insumoId');
+  }
+}

--- a/lib/features/recipe/ui/add_ingredient_sheet.dart
+++ b/lib/features/recipe/ui/add_ingredient_sheet.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/theme/app_spacing.dart';
+import '../../products/data/models/product.dart';
+import '../data/models/recipe_line.dart';
+import '../widgets/autocomplete_insumo_field.dart';
+
+class AddIngredientSheet extends HookConsumerWidget {
+  const AddIngredientSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final selected = useState<Product?>(null);
+    final qtyCtrl = useTextEditingController(text: '1');
+    final mermaCtrl = useTextEditingController(text: '0');
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: spacing.md,
+        right: spacing.md,
+        top: spacing.md,
+        bottom: MediaQuery.of(context).viewInsets.bottom + spacing.md,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AutocompleteInsumoField(onSelected: (p) => selected.value = p),
+          SizedBox(height: spacing.md),
+          TextField(
+            controller: qtyCtrl,
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(labelText: 'Cantidad'),
+          ),
+          SizedBox(height: spacing.md),
+          TextField(
+            controller: mermaCtrl,
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(labelText: 'Merma %'),
+          ),
+          SizedBox(height: spacing.lg),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancelar'),
+              ),
+              SizedBox(width: spacing.md),
+              FilledButton(
+                onPressed: () {
+                  final p = selected.value;
+                  final qty = double.tryParse(qtyCtrl.text) ?? 0;
+                  final merma = double.tryParse(mermaCtrl.text) ?? 0;
+                  if (p == null || qty <= 0 || merma < 0 || merma > 100) {
+                    Navigator.pop(context);
+                    return;
+                  }
+                  Navigator.pop(
+                    context,
+                    RecipeLine(
+                      insumoId: p.id,
+                      insumoCodigo: p.codigo,
+                      insumoNombre: p.nombre,
+                      unidadId: p.unidadId,
+                      unidadCodigo: p.unidadCodigo,
+                      cantidad: qty,
+                      mermaPorcentaje: merma,
+                    ),
+                  );
+                },
+                child: const Text('Agregar'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/recipe/ui/recipe_page.dart
+++ b/lib/features/recipe/ui/recipe_page.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/theme/app_spacing.dart';
+import '../../products/data/models/product.dart';
+import '../controllers/recipe_controller.dart';
+import '../data/models/recipe_line.dart';
+import '../widgets/recipe_line_tile.dart';
+import 'add_ingredient_sheet.dart';
+
+class RecipePage extends HookConsumerWidget {
+  const RecipePage({super.key, required this.product});
+
+  final Product product;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final state = ref.watch(recipeControllerProvider);
+    final controller = ref.read(recipeControllerProvider.notifier);
+
+    useEffect(() {
+      controller.load(product.id);
+      return null;
+    }, const []);
+
+    Future<void> _add() async {
+      final line = await showModalBottomSheet<RecipeLine>(
+        context: context,
+        isScrollControlled: true,
+        builder: (_) => const AddIngredientSheet(),
+      );
+      if (line != null) {
+        final err = await controller.addLine(line);
+        if (err != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(err)),
+          );
+        }
+      }
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Receta de ${product.nombre}'),
+        actions: [
+          if (state.dirty)
+            TextButton(
+              onPressed: () => controller.saveAll(product.id),
+              child: const Text('Guardar'),
+            ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _add,
+        child: const Icon(Icons.add),
+      ),
+      body: Padding(
+        padding: EdgeInsets.all(spacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(product.codigo),
+            Text(product.categoriaNombre ?? ''),
+            Text(product.unidadCodigo ?? ''),
+            Text('\$${product.precio.toStringAsFixed(2)}'),
+            SizedBox(height: spacing.lg),
+            Expanded(
+              child: state.isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : state.lines.isEmpty
+                      ? const Center(child: Text('Aún no has agregado insumos'))
+                      : ListView.builder(
+                          itemCount: state.lines.length,
+                          itemBuilder: (context, index) {
+                            final line = state.lines[index];
+                            return RecipeLineTile(
+                              line: line,
+                              onChanged: controller.updateLine,
+                              onDelete: () async {
+                                final confirm = await showDialog<bool>(
+                                  context: context,
+                                  builder: (_) => AlertDialog(
+                                    title: const Text('Eliminar'),
+                                    content: const Text(
+                                        '¿Eliminar este insumo de la receta?'),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () =>
+                                            Navigator.pop(context, false),
+                                        child: const Text('Cancelar'),
+                                      ),
+                                      TextButton(
+                                        onPressed: () =>
+                                            Navigator.pop(context, true),
+                                        child: const Text('Eliminar'),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                                if (confirm == true) {
+                                  await controller.deleteLine(
+                                      product.id, line.insumoId);
+                                }
+                              },
+                            );
+                          },
+                        ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/recipe/widgets/autocomplete_insumo_field.dart
+++ b/lib/features/recipe/widgets/autocomplete_insumo_field.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../products/data/models/product.dart';
+import '../../products/data/products_repository.dart';
+
+class AutocompleteInsumoField extends HookConsumerWidget {
+  const AutocompleteInsumoField({super.key, required this.onSelected});
+
+  final ValueChanged<Product> onSelected;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ctrl = useTextEditingController();
+    final results = useState<List<Product>>([]);
+    final debounce = useRef<Timer?>(null);
+
+    useEffect(() {
+      void listener() {
+        debounce.value?.cancel();
+        debounce.value = Timer(const Duration(milliseconds: 400), () async {
+          final repo = ref.read(productsRepositoryProvider);
+          final list = await repo.searchInsumos(ctrl.text);
+          results.value = list;
+        });
+      }
+
+      ctrl.addListener(listener);
+      return () {
+        ctrl.removeListener(listener);
+        debounce.value?.cancel();
+      };
+    }, [ctrl]);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextField(
+          controller: ctrl,
+          decoration: const InputDecoration(labelText: 'Insumo'),
+        ),
+        ...results.value.map(
+          (p) => ListTile(
+            title: Text(p.nombre),
+            subtitle: Text(p.codigo),
+            onTap: () {
+              onSelected(p);
+              ctrl.text = '${p.nombre} (${p.codigo})';
+              results.value = [];
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/recipe/widgets/recipe_line_tile.dart
+++ b/lib/features/recipe/widgets/recipe_line_tile.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import '../../../core/theme/app_spacing.dart';
+import '../data/models/recipe_line.dart';
+
+class RecipeLineTile extends HookWidget {
+  const RecipeLineTile({
+    super.key,
+    required this.line,
+    required this.onChanged,
+    required this.onDelete,
+  });
+
+  final RecipeLine line;
+  final ValueChanged<RecipeLine> onChanged;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final qtyCtrl = useTextEditingController(text: line.cantidad.toString());
+    final mermaCtrl =
+        useTextEditingController(text: line.mermaPorcentaje.toString());
+
+    useEffect(() {
+      qtyCtrl.text = line.cantidad.toString();
+      mermaCtrl.text = line.mermaPorcentaje.toString();
+      return null;
+    }, [line]);
+
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: spacing.sm),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(line.insumoNombre ?? ''),
+                if (line.insumoCodigo != null)
+                  Text(
+                    line.insumoCodigo!,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                if (line.unidadCodigo != null)
+                  Padding(
+                    padding: EdgeInsets.only(top: spacing.xs),
+                    child: Chip(label: Text(line.unidadCodigo!)),
+                  ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: spacing.xl * 3,
+            child: TextField(
+              controller: qtyCtrl,
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+              decoration: const InputDecoration(labelText: 'Cantidad'),
+              onChanged: (v) {
+                final value = double.tryParse(v) ?? line.cantidad;
+                onChanged(line.copyWith(cantidad: value));
+              },
+            ),
+          ),
+          SizedBox(width: spacing.sm),
+          SizedBox(
+            width: spacing.xl * 3,
+            child: TextField(
+              controller: mermaCtrl,
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+              decoration: const InputDecoration(labelText: 'Merma %'),
+              onChanged: (v) {
+                final value = double.tryParse(v) ?? line.mermaPorcentaje;
+                onChanged(line.copyWith(mermaPorcentaje: value));
+              },
+            ),
+          ),
+          IconButton(onPressed: onDelete, icon: const Icon(Icons.delete)),
+        ],
+      ),
+    );
+  }
+}

--- a/test/recipe_controller_test.dart
+++ b/test/recipe_controller_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:punto_venta_front/features/recipe/controllers/recipe_controller.dart';
+import 'package:punto_venta_front/features/recipe/data/models/recipe_line.dart';
+import 'package:punto_venta_front/features/recipe/data/recipe_repository.dart';
+
+class MockRecipeRepository extends Mock implements RecipeRepository {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      RecipeLine(
+        insumoId: 1,
+        insumoCodigo: 'A',
+        insumoNombre: 'A',
+        cantidad: 1,
+        mermaPorcentaje: 0,
+      ),
+    );
+    registerFallbackValue(<RecipeLine>[]);
+  });
+
+  group('RecipeController', () {
+    test('addLine rejects duplicates', () async {
+      final repo = MockRecipeRepository();
+      final container = ProviderContainer(overrides: [
+        recipeRepositoryProvider.overrideWithValue(repo),
+      ]);
+      final controller = container.read(recipeControllerProvider.notifier);
+      final line = RecipeLine(
+        insumoId: 1,
+        insumoCodigo: 'A',
+        insumoNombre: 'A',
+        cantidad: 1,
+        mermaPorcentaje: 0,
+      );
+      await controller.addLine(line);
+      final err = await controller.addLine(line);
+      expect(err, isNotNull);
+    });
+
+    test('saveAll sends full list', () async {
+      final repo = MockRecipeRepository();
+      when(() => repo.saveRecipe(any(), any())).thenAnswer((invocation) async {
+        final lines = invocation.positionalArguments[1] as List<RecipeLine>;
+        return lines;
+      });
+      final container = ProviderContainer(overrides: [
+        recipeRepositoryProvider.overrideWithValue(repo),
+      ]);
+      final controller = container.read(recipeControllerProvider.notifier);
+      await controller.addLine(
+        RecipeLine(
+          insumoId: 1,
+          insumoCodigo: 'A',
+          insumoNombre: 'A',
+          cantidad: 1,
+          mermaPorcentaje: 0,
+        ),
+      );
+      await controller.addLine(
+        RecipeLine(
+          insumoId: 2,
+          insumoCodigo: 'B',
+          insumoNombre: 'B',
+          cantidad: 2,
+          mermaPorcentaje: 10,
+        ),
+      );
+      await controller.saveAll(1);
+      verify(() => repo.saveRecipe(1, any())).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- support product recipe CRUD with repository and controller
- add UI to manage ingredients with validations and autocomplete
- document recipe endpoints and register API calls

## Testing
- `dart format lib test` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c6be4ca4832f8d421d86e62dd949