### PR TITLE
feat: add invoice detail screen with SRI integration

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -11,6 +11,7 @@ import '../../features/auth/ui/login_page.dart';
 import '../../features/dashboard/ui/dashboard_page.dart';
 import '../../features/_placeholders_/selector_local_page.dart';
 import '../../features/products/ui/products_page.dart';
+import '../../features/invoices/ui/invoice_detail_page.dart';
 
 class GoRouterRefreshStream extends ChangeNotifier {
   GoRouterRefreshStream(Stream<dynamic> stream) {
@@ -53,6 +54,13 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/productos',
         builder: (context, state) => const ProductsPage(),
+      ),
+      GoRoute(
+        path: '/facturas/:id',
+        builder: (context, state) {
+          final id = int.parse(state.params['id']!);
+          return InvoiceDetailPage(id: id);
+        },
       ),
     ],
     redirect: (context, state) {

--- a/lib/features/invoices/controllers/invoice_detail_controller.dart
+++ b/lib/features/invoices/controllers/invoice_detail_controller.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../data/invoices_repository.dart';
+import '../data/models/invoice.dart';
+import 'invoice_detail_state.dart';
+
+final invoiceDetailControllerProvider =
+    StateNotifierProvider<InvoiceDetailController, InvoiceDetailState>(
+        (ref) {
+  return InvoiceDetailController(ref);
+});
+
+class InvoiceDetailController extends StateNotifier<InvoiceDetailState> {
+  InvoiceDetailController(this._ref) : super(const InvoiceDetailState());
+
+  final Ref _ref;
+  Timer? _timer;
+  int _attempts = 0;
+
+  Future<void> load(int id) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final repo = _ref.read(invoicesRepositoryProvider);
+      final invoice = await repo.getInvoice(id);
+      state = state.copyWith(invoice: invoice);
+    } catch (e) {
+      state = state.copyWith(error: e.toString());
+    } finally {
+      state = state.copyWith(isLoading: false);
+    }
+  }
+
+  Future<void> emit(int id) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final repo = _ref.read(invoicesRepositoryProvider);
+      final status = await repo.emit(id);
+      state = state.copyWith(
+          invoice: state.invoice?.copyWith(estadoSri: status));
+      if (status == 'enviada') {
+        startPolling(id);
+      }
+    } catch (e) {
+      state = state.copyWith(error: e.toString());
+    } finally {
+      state = state.copyWith(isLoading: false);
+    }
+  }
+
+  void startPolling(int id,
+      {Duration interval = const Duration(seconds: 3), int maxAttempts = 20}) {
+    stopPolling();
+    _attempts = 0;
+    state = state.copyWith(isPolling: true);
+    _timer = Timer.periodic(interval, (timer) async {
+      _attempts++;
+      if (_attempts > maxAttempts) {
+        stopPolling();
+        return;
+      }
+      final repo = _ref.read(invoicesRepositoryProvider);
+      try {
+        final invoice = await repo.getInvoice(id);
+        state = state.copyWith(invoice: invoice);
+        if (invoice.estadoSri == 'autorizada' ||
+            invoice.estadoSri == 'rechazada') {
+          stopPolling();
+        }
+      } catch (_) {}
+    });
+  }
+
+  void stopPolling() {
+    _timer?.cancel();
+    state = state.copyWith(isPolling: false);
+  }
+
+  Future<void> downloadPdf(int id) async {
+    final repo = _ref.read(invoicesRepositoryProvider);
+    await repo.downloadPdf(id);
+  }
+
+  Future<void> downloadXml(int id) async {
+    final repo = _ref.read(invoicesRepositoryProvider);
+    await repo.downloadXml(id);
+  }
+}

--- a/lib/features/invoices/controllers/invoice_detail_state.dart
+++ b/lib/features/invoices/controllers/invoice_detail_state.dart
@@ -1,0 +1,33 @@
+import '../data/models/invoice.dart';
+
+class InvoiceDetailState {
+  const InvoiceDetailState({
+    this.isLoading = false,
+    this.invoice,
+    this.error,
+    this.isPolling = false,
+  });
+
+  final bool isLoading;
+  final Invoice? invoice;
+  final String? error;
+  final bool isPolling;
+
+  bool get canEmit =>
+      invoice != null &&
+      (invoice!.estadoSri == 'pendiente' || invoice!.estadoSri == 'rechazada');
+
+  InvoiceDetailState copyWith({
+    bool? isLoading,
+    Invoice? invoice,
+    String? error,
+    bool? isPolling,
+  }) {
+    return InvoiceDetailState(
+      isLoading: isLoading ?? this.isLoading,
+      invoice: invoice ?? this.invoice,
+      error: error,
+      isPolling: isPolling ?? this.isPolling,
+    );
+  }
+}

--- a/lib/features/invoices/data/invoices_repository.dart
+++ b/lib/features/invoices/data/invoices_repository.dart
@@ -1,0 +1,75 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/network/dio_client.dart';
+import 'models/invoice.dart';
+
+final invoicesRepositoryProvider = Provider<InvoicesRepository>((ref) {
+  final dio = ref.read(dioProvider);
+  return InvoicesRepository(dio);
+});
+
+/// Repository that handles API calls for invoices supporting fallback paths.
+class InvoicesRepository {
+  InvoicesRepository(this._dio);
+
+  final Dio _dio;
+
+  Future<Response<dynamic>> _requestWithFallback(
+    String method,
+    String primary,
+    String fallback, {
+    Options? options,
+    data,
+  }) async {
+    try {
+      return await _dio.request(primary,
+          data: data, options: options, method: method);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        return await _dio.request(fallback,
+            data: data, options: options, method: method);
+      }
+      rethrow;
+    }
+  }
+
+  Future<Invoice> getInvoice(int id) async {
+    final resp = await _requestWithFallback(
+      'GET',
+      '/v1/facturas/$id',
+      '/v1/ventas/facturas/$id',
+    );
+    return Invoice.fromJson(Map<String, dynamic>.from(resp.data));
+  }
+
+  Future<String> emit(int id) async {
+    final key = 'EMIT-$id-${DateTime.now().microsecondsSinceEpoch}';
+    final options = Options(headers: {'Idempotency-Key': key});
+    final resp = await _requestWithFallback(
+      'POST',
+      '/v1/facturas/$id/emitir',
+      '/v1/ventas/facturas/$id/emitir',
+      options: options,
+    );
+    return (resp.data as Map<String, dynamic>)['estado_sri'] as String;
+  }
+
+  Future<Response<dynamic>> downloadPdf(int id) async {
+    return _requestWithFallback(
+      'GET',
+      '/v1/facturas/$id/pdf',
+      '/v1/ventas/facturas/$id/pdf',
+      options: Options(responseType: ResponseType.bytes),
+    );
+  }
+
+  Future<Response<dynamic>> downloadXml(int id) async {
+    return _requestWithFallback(
+      'GET',
+      '/v1/facturas/$id/xml',
+      '/v1/ventas/facturas/$id/xml',
+      options: Options(responseType: ResponseType.bytes),
+    );
+  }
+}

--- a/lib/features/invoices/data/models/invoice.dart
+++ b/lib/features/invoices/data/models/invoice.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+/// Represents an invoice detail returned by the API.
+class Invoice {
+  const Invoice({
+    required this.id,
+    required this.numero,
+    required this.fechaEmision,
+    required this.cliente,
+    required this.estadoSri,
+    this.claveAcceso,
+    required this.totales,
+    this.mensajesSri = const [],
+  });
+
+  final int id;
+  final String? numero;
+  final DateTime? fechaEmision;
+  final InvoiceCustomer? cliente;
+  final String estadoSri;
+  final String? claveAcceso;
+  final InvoiceTotals totales;
+  final List<SriMessage> mensajesSri;
+
+  factory Invoice.fromJson(Map<String, dynamic> json) {
+    return Invoice(
+      id: json['id'] as int,
+      numero: json['numero'] as String?,
+      fechaEmision: json['fecha_emision'] != null
+          ? DateTime.tryParse(json['fecha_emision'] as String)
+          : null,
+      cliente: json['cliente'] != null
+          ? InvoiceCustomer.fromJson(
+              Map<String, dynamic>.from(json['cliente'] as Map))
+          : null,
+      estadoSri: json['estado_sri'] as String,
+      claveAcceso: json['clave_acceso'] as String?,
+      totales: InvoiceTotals.fromJson(
+        Map<String, dynamic>.from(json['totales'] as Map),
+      ),
+      mensajesSri: (json['mensajes_sri'] as List<dynamic>?)
+              ?.map((e) => SriMessage.fromJson(Map<String, dynamic>.from(e)))
+              .toList() ??
+          const [],
+    );
+  }
+
+  Invoice copyWith({String? estadoSri, List<SriMessage>? mensajesSri}) {
+    return Invoice(
+      id: id,
+      numero: numero,
+      fechaEmision: fechaEmision,
+      cliente: cliente,
+      estadoSri: estadoSri ?? this.estadoSri,
+      claveAcceso: claveAcceso,
+      totales: totales,
+      mensajesSri: mensajesSri ?? this.mensajesSri,
+    );
+  }
+}
+
+/// Customer info of the invoice.
+class InvoiceCustomer {
+  const InvoiceCustomer({
+    required this.id,
+    required this.identificacion,
+    required this.nombre,
+  });
+
+  final int id;
+  final String identificacion;
+  final String nombre;
+
+  factory InvoiceCustomer.fromJson(Map<String, dynamic> json) {
+    return InvoiceCustomer(
+      id: json['id'] as int,
+      identificacion: json['identificacion'] as String,
+      nombre: json['nombre'] as String,
+    );
+  }
+}
+
+/// Totals section of the invoice.
+class InvoiceTotals {
+  const InvoiceTotals({
+    required this.subtotal,
+    required this.descuento,
+    required this.iva,
+    required this.total,
+  });
+
+  final double subtotal;
+  final double descuento;
+  final double iva;
+  final double total;
+
+  factory InvoiceTotals.fromJson(Map<String, dynamic> json) {
+    return InvoiceTotals(
+      subtotal: (json['subtotal'] as num).toDouble(),
+      descuento: (json['descuento'] as num).toDouble(),
+      iva: (json['iva'] as num).toDouble(),
+      total: (json['total'] as num).toDouble(),
+    );
+  }
+}
+
+/// Message from SRI detailing processing info or errors.
+class SriMessage {
+  const SriMessage({
+    required this.tipo,
+    required this.codigo,
+    required this.detalle,
+  });
+
+  final String tipo;
+  final String codigo;
+  final String detalle;
+
+  factory SriMessage.fromJson(Map<String, dynamic> json) {
+    return SriMessage(
+      tipo: json['tipo'] as String,
+      codigo: json['codigo'] as String,
+      detalle: json['detalle'] as String,
+    );
+  }
+}

--- a/lib/features/invoices/ui/invoice_detail_page.dart
+++ b/lib/features/invoices/ui/invoice_detail_page.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/theme/app_spacing.dart';
+import '../controllers/invoice_detail_controller.dart';
+import '../controllers/invoice_detail_state.dart';
+import '../data/models/invoice.dart';
+import 'widgets/status_chip.dart';
+
+class InvoiceDetailPage extends HookConsumerWidget {
+  const InvoiceDetailPage({super.key, required this.id});
+
+  final int id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final controller = ref.read(invoiceDetailControllerProvider.notifier);
+    final state = ref.watch(invoiceDetailControllerProvider);
+
+    useEffect(() {
+      controller.load(id);
+      return null;
+    }, const []);
+
+    final invoice = state.invoice;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Factura #${invoice?.numero ?? ''}'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.picture_as_pdf),
+            onPressed: () => controller.downloadPdf(id),
+          ),
+          IconButton(
+            icon: const Icon(Icons.code),
+            onPressed: () => controller.downloadXml(id),
+          ),
+        ],
+      ),
+      body: state.isLoading && invoice == null
+          ? const Center(child: CircularProgressIndicator())
+          : invoice == null
+              ? const Center(child: Text('No encontrada'))
+              : Padding(
+                  padding: EdgeInsets.all(spacing.md),
+                  child: ListView(
+                    children: [
+                      _Header(invoice: invoice),
+                      SizedBox(height: spacing.lg),
+                      _Totals(totals: invoice.totales),
+                      SizedBox(height: spacing.lg),
+                      if (state.canEmit)
+                        ElevatedButton(
+                          onPressed: state.isLoading
+                              ? null
+                              : () => controller.emit(id),
+                          child: state.isLoading
+                              ? const CircularProgressIndicator()
+                              : const Text('Emitir ahora'),
+                        ),
+                    ],
+                  ),
+                ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.invoice});
+
+  final Invoice invoice;
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(child: Text(invoice.numero ?? 'Borrador')),
+            StatusChip(estado: invoice.estadoSri),
+          ],
+        ),
+        if (invoice.cliente != null) ...[
+          SizedBox(height: spacing.sm),
+          Text('${invoice.cliente!.nombre} (${invoice.cliente!.identificacion})'),
+        ],
+      ],
+    );
+  }
+}
+
+class _Totals extends StatelessWidget {
+  const _Totals({required this.totals});
+
+  final InvoiceTotals totals;
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text('Subtotal: ${totals.subtotal.toStringAsFixed(2)}'),
+        Text('Descuento: ${totals.descuento.toStringAsFixed(2)}'),
+        Text('IVA: ${totals.iva.toStringAsFixed(2)}'),
+        Text('Total: ${totals.total.toStringAsFixed(2)}'),
+      ],
+    );
+  }
+}

--- a/lib/features/invoices/ui/widgets/status_chip.dart
+++ b/lib/features/invoices/ui/widgets/status_chip.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/app_radius.dart';
+import '../../../../core/theme/app_spacing.dart';
+
+/// Chip that displays the current SRI status of the invoice.
+class StatusChip extends StatelessWidget {
+  const StatusChip({super.key, required this.estado});
+
+  final String estado;
+
+  Color _color(AppColors colors) {
+    switch (estado) {
+      case 'autorizada':
+        return colors.success;
+      case 'rechazada':
+        return colors.error;
+      case 'enviada':
+        return colors.info;
+      default:
+        return colors.n500;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<AppColors>()!;
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final radius = Theme.of(context).extension<AppRadius>()!;
+    final bg = _color(colors).withOpacity(0.1);
+    return Container(
+      padding:
+          EdgeInsets.symmetric(horizontal: spacing.sm, vertical: spacing.xs),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(radius.pill),
+      ),
+      child: Text(
+        estado,
+        style: TextStyle(color: _color(colors)),
+      ),
+    );
+  }
+}

--- a/test/invoice_detail_controller_test.dart
+++ b/test/invoice_detail_controller_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:punto_venta_front/features/invoices/controllers/invoice_detail_controller.dart';
+import 'package:punto_venta_front/features/invoices/controllers/invoice_detail_state.dart';
+import 'package:punto_venta_front/features/invoices/data/invoices_repository.dart';
+import 'package:punto_venta_front/features/invoices/data/models/invoice.dart';
+
+class MockInvoicesRepository extends Mock implements InvoicesRepository {}
+
+Invoice buildInvoice(String status) {
+  return Invoice(
+    id: 1,
+    numero: '001',
+    fechaEmision: DateTime.now(),
+    cliente: const InvoiceCustomer(id: 1, identificacion: '123', nombre: 'A'),
+    estadoSri: status,
+    totales: const InvoiceTotals(
+      subtotal: 0,
+      descuento: 0,
+      iva: 0,
+      total: 0,
+    ),
+  );
+}
+
+void main() {
+  test('polling stops when invoice becomes autorizada', () async {
+    final repo = MockInvoicesRepository();
+    when(() => repo.getInvoice(1))
+        .thenAnswer((_) async => buildInvoice('enviada'))
+        .thenAnswer((_) async => buildInvoice('autorizada'));
+    final container = ProviderContainer(overrides: [
+      invoicesRepositoryProvider.overrideWithValue(repo),
+    ]);
+    final controller =
+        container.read(invoiceDetailControllerProvider.notifier);
+    controller.startPolling(1,
+        interval: const Duration(milliseconds: 10), maxAttempts: 5);
+    await Future.delayed(const Duration(milliseconds: 50));
+    final state = container.read(invoiceDetailControllerProvider);
+    expect(state.isPolling, false);
+    expect(state.invoice?.estadoSri, 'autorizada');
+  });
+
+  test('polling stops after maxAttempts', () async {
+    final repo = MockInvoicesRepository();
+    when(() => repo.getInvoice(1)).thenAnswer((_) async => buildInvoice('enviada'));
+    final container = ProviderContainer(overrides: [
+      invoicesRepositoryProvider.overrideWithValue(repo),
+    ]);
+    final controller =
+        container.read(invoiceDetailControllerProvider.notifier);
+    controller.startPolling(1,
+        interval: const Duration(milliseconds: 10), maxAttempts: 3);
+    await Future.delayed(const Duration(milliseconds: 50));
+    final state = container.read(invoiceDetailControllerProvider);
+    expect(state.isPolling, false);
+  });
+}

--- a/test/invoices_repository_test.dart
+++ b/test/invoices_repository_test.dart
@@ -1,0 +1,72 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:punto_venta_front/features/invoices/data/invoices_repository.dart';
+import 'package:punto_venta_front/features/invoices/data/models/invoice.dart';
+
+class MockDio extends Mock implements Dio {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Options());
+  });
+
+  test('getInvoice falls back to legacy path on 404', () async {
+    final dio = MockDio();
+    when(() => dio.request('/v1/facturas/1',
+            method: 'GET', data: null, options: any(named: 'options')))
+        .thenThrow(DioException(
+            requestOptions: RequestOptions(path: '/v1/facturas/1'),
+            response: Response(
+                requestOptions: RequestOptions(path: '/v1/facturas/1'),
+                statusCode: 404)));
+    when(() => dio.request('/v1/ventas/facturas/1',
+            method: 'GET', data: null, options: any(named: 'options')))
+        .thenAnswer((_) async => Response(
+              requestOptions: RequestOptions(path: '/v1/ventas/facturas/1'),
+              statusCode: 200,
+              data: {
+                'id': 1,
+                'numero': '001',
+                'estado_sri': 'pendiente',
+                'totales': {
+                  'subtotal': 0,
+                  'descuento': 0,
+                  'iva': 0,
+                  'total': 0,
+                }
+              },
+            ));
+    final repo = InvoicesRepository(dio);
+    final invoice = await repo.getInvoice(1);
+    expect(invoice.id, 1);
+    verify(() => dio.request('/v1/facturas/1',
+        method: 'GET', data: null, options: any(named: 'options'))).called(1);
+    verify(() => dio.request('/v1/ventas/facturas/1',
+        method: 'GET', data: null, options: any(named: 'options'))).called(1);
+  });
+
+  test('emit adds Idempotency-Key header', () async {
+    final dio = MockDio();
+    when(() => dio.request('/v1/facturas/1/emitir',
+            method: 'POST', data: null, options: any(named: 'options')))
+        .thenAnswer((invocation) async {
+      return Response(
+        requestOptions: RequestOptions(path: '/v1/facturas/1/emitir'),
+        statusCode: 200,
+        data: {'estado_sri': 'enviada'},
+      );
+    });
+    final repo = InvoicesRepository(dio);
+    final status = await repo.emit(1);
+    expect(status, 'enviada');
+    final captured = verify(() => dio.request('/v1/facturas/1/emitir',
+            method: 'POST', data: null, options: captureAny(named: 'options')))
+        .captured
+        .first as Options;
+    final key = captured.headers?['Idempotency-Key'] as String?;
+    expect(key, isNotNull);
+    expect(key, startsWith('EMIT-1-'));
+  });
+}


### PR DESCRIPTION
## Summary
- add repository with fallback to legacy invoice routes and idempotent emission
- introduce invoice detail controller with polling and download helpers
- create invoice detail page with status chip and totals using theme tokens

## Testing
- `flutter test` *(fails: command not found)*
- `git clone https://github.com/flutter/flutter.git -b stable --depth 1 /usr/local/flutter` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ce1a2a5c832f8b2cdfef095a6e09