### PR TITLE
feat: support invoice cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,31 @@ Ejemplo:
 flutter run --dart-define=BASE_URL=https://api.staging.tuapp.com -d chrome
 ```
 
+## Frontend / Anulación - Nota de Crédito
+
+Flujo de anulación de factura que genera una Nota de Crédito electrónica.
+
+### Flujo
+
+1. El usuario ingresa el **motivo** (10–200 caracteres).
+2. `POST /v1/facturas/{id}/anular` crea la NC usando el encabezado `Idempotency-Key: NC-<facturaId>-<uuid>`.
+3. La respuesta retorna `nota_credito_id`, número (si existe) y `estado_sri` para mostrar el resultado.
+
+### Manejo de errores
+
+- **409**: factura ya anulada.
+- **422**: factura no elegible; se muestra el mensaje del backend.
+- Estados SRI `rechazada` incluyen `mensajes` para feedback y permiten reintentar.
+
+### Endpoints usados
+
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| POST | `/v1/facturas/{id}/anular` | Genera nota de crédito |
+| GET | `/v1/ventas/notas-credito` | Listar Notas de Crédito |
+
+Las descargas de PDF/XML de la NC se habilitarán cuando el backend exponga `/v1/notas-credito/{id}/pdf` y `/v1/notas-credito/{id}/xml`.
+
 ## Guard Global
 
 El router redirige las rutas protegidas según el estado:

--- a/api_registry.json
+++ b/api_registry.json
@@ -56,4 +56,6 @@
     {"method":"POST","path":"/v1/facturas","name":"Crear factura (por cuenta_id)","module":"ventas","permission":"facturas.crear"},
     {"method":"POST","path":"/v1/pagos-venta","name":"Registrar pago de venta","module":"ventas","permission":"ventas.pagos.crear"},
     {"method":"GET","path":"/v1/metodos-pago","name":"Listar métodos de pago","module":"metodos_pago","permission":"metodos_pago.ver"}
+    ,{"method":"POST","path":"/v1/facturas/{id}/anular","name":"Anular factura (genera NC)","module":"facturas","permission":"facturas.anular"}
+    ,{"method":"GET","path":"/v1/ventas/notas-credito","name":"Listar Notas de Crédito","module":"notas_credito","permission":"notas_credito.ver"}
 ]

--- a/lib/data/auth/auth_repository.dart
+++ b/lib/data/auth/auth_repository.dart
@@ -160,3 +160,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
     state = const Unauthenticated();
   }
 }
+
+/// Provider to check if current user has a specific permission.
+final hasPermissionProvider = Provider.family<bool, String>((ref, perm) {
+  final auth = ref.watch(authStateProvider);
+  return auth is Authenticated && auth.user.permisos.contains(perm);
+});

--- a/lib/data/auth/user.dart
+++ b/lib/data/auth/user.dart
@@ -1,18 +1,28 @@
 class User {
-  const User({required this.id, required this.nombre, required this.email});
+  const User({
+    required this.id,
+    required this.nombre,
+    required this.email,
+    this.permisos = const [],
+  });
+
   final int id;
   final String nombre;
   final String email;
+  final List<String> permisos;
 
   factory User.fromJson(Map<String, dynamic> json) => User(
         id: json['id'] as int,
         nombre: json['nombre'] as String,
         email: json['email'] as String,
+        permisos:
+            (json['permisos'] as List<dynamic>? ?? []).cast<String>(),
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'nombre': nombre,
         'email': email,
+        'permisos': permisos,
       };
 }

--- a/lib/features/invoices/controllers/invoice_detail_state.dart
+++ b/lib/features/invoices/controllers/invoice_detail_state.dart
@@ -17,6 +17,10 @@ class InvoiceDetailState {
       invoice != null &&
       (invoice!.estadoSri == 'pendiente' || invoice!.estadoSri == 'rechazada');
 
+  bool get canCancel =>
+      invoice != null &&
+      (invoice!.estadoSri == 'autorizada' || invoice!.estadoSri == 'enviada');
+
   InvoiceDetailState copyWith({
     bool? isLoading,
     Invoice? invoice,

--- a/lib/features/invoices/data/models/cancel_result.dart
+++ b/lib/features/invoices/data/models/cancel_result.dart
@@ -1,0 +1,31 @@
+import 'invoice.dart';
+
+/// Result of cancelling an invoice which generates a credit note.
+class CancelInvoiceResult {
+  const CancelInvoiceResult({
+    required this.facturaId,
+    required this.notaCreditoId,
+    this.ncNumero,
+    required this.estadoSri,
+    this.mensajes = const [],
+  });
+
+  final int facturaId;
+  final int notaCreditoId;
+  final String? ncNumero;
+  final String estadoSri;
+  final List<SriMessage> mensajes;
+
+  factory CancelInvoiceResult.fromJson(Map<String, dynamic> json) {
+    return CancelInvoiceResult(
+      facturaId: json['factura_id'] as int,
+      notaCreditoId: json['nota_credito_id'] as int,
+      ncNumero: json['nc_numero'] as String?,
+      estadoSri: json['estado_sri'] as String,
+      mensajes: (json['mensajes'] as List<dynamic>?)
+              ?.map((e) => SriMessage.fromJson(Map<String, dynamic>.from(e)))
+              .toList() ??
+          const [],
+    );
+  }
+}

--- a/lib/features/invoices/ui/invoice_detail_page.dart
+++ b/lib/features/invoices/ui/invoice_detail_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../core/theme/app_spacing.dart';
+import '../../../data/auth/auth_repository.dart';
+import '../../invoicing/ui/cancel_invoice_dialog.dart';
 import '../controllers/invoice_detail_controller.dart';
 import '../controllers/invoice_detail_state.dart';
 import '../data/models/invoice.dart';
@@ -59,6 +61,17 @@ class InvoiceDetailPage extends HookConsumerWidget {
                           child: state.isLoading
                               ? const CircularProgressIndicator()
                               : const Text('Emitir ahora'),
+                      ),
+                      if (state.canCancel &&
+                          ref.watch(hasPermissionProvider('facturas.anular')))
+                        ElevatedButton(
+                          onPressed: () async {
+                            await showDialog(
+                              context: context,
+                              builder: (_) => CancelInvoiceDialog(invoiceId: id),
+                            );
+                          },
+                          child: const Text('Anular'),
                         ),
                     ],
                   ),

--- a/lib/features/invoicing/controllers/cancel_invoice_controller.dart
+++ b/lib/features/invoicing/controllers/cancel_invoice_controller.dart
@@ -1,0 +1,76 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../invoices/data/invoices_repository.dart';
+import '../../invoices/data/models/cancel_result.dart';
+
+class CancelInvoiceState {
+  const CancelInvoiceState({
+    this.isSending = false,
+    this.error,
+    this.result,
+  });
+
+  final bool isSending;
+  final String? error;
+  final CancelInvoiceResult? result;
+
+  CancelInvoiceState copyWith({
+    bool? isSending,
+    String? error,
+    CancelInvoiceResult? result,
+  }) =>
+      CancelInvoiceState(
+        isSending: isSending ?? this.isSending,
+        error: error,
+        result: result ?? this.result,
+      );
+}
+
+final cancelInvoiceControllerProvider =
+    StateNotifierProvider<CancelInvoiceController, CancelInvoiceState>((ref) {
+  return CancelInvoiceController(ref);
+});
+
+class CancelInvoiceController extends StateNotifier<CancelInvoiceState> {
+  CancelInvoiceController(this._ref) : super(const CancelInvoiceState());
+
+  final Ref _ref;
+
+  Future<void> submit(int facturaId, String motivo) async {
+    final validation = validateMotivo(motivo);
+    if (validation != null) {
+      state = state.copyWith(error: validation);
+      return;
+    }
+    state = state.copyWith(isSending: true, error: null);
+    try {
+      final repo = _ref.read(invoicesRepositoryProvider);
+      final result = await repo.cancel(facturaId, motivo);
+      state = state.copyWith(result: result);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 409) {
+        state = state.copyWith(error: 'Factura ya anulada');
+      } else if (e.response?.statusCode == 422) {
+        final msg = e.response?.data['message'];
+        state =
+            state.copyWith(error: msg is String ? msg : 'No se puede anular');
+      } else {
+        state = state.copyWith(error: 'Error al anular');
+      }
+    } catch (_) {
+      state = state.copyWith(error: 'Error al anular');
+    } finally {
+      state = state.copyWith(isSending: false);
+    }
+  }
+}
+
+String? validateMotivo(String? value) {
+  final v = value?.trim() ?? '';
+  if (v.isEmpty) return 'Motivo requerido';
+  if (v.length < 10 || v.length > 200) {
+    return 'Debe tener entre 10 y 200 caracteres';
+  }
+  return null;
+}

--- a/lib/features/invoicing/ui/cancel_invoice_dialog.dart
+++ b/lib/features/invoicing/ui/cancel_invoice_dialog.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/theme/app_spacing.dart';
+import '../../invoices/data/models/cancel_result.dart';
+import '../controllers/cancel_invoice_controller.dart';
+import 'result_card.dart';
+
+class CancelInvoiceDialog extends HookConsumerWidget {
+  const CancelInvoiceDialog({super.key, required this.invoiceId});
+
+  final int invoiceId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final formKey = useMemoized(() => GlobalKey<FormState>());
+    final motivoCtrl = useTextEditingController();
+    final state = ref.watch(cancelInvoiceControllerProvider);
+
+    Widget buildForm() {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextFormField(
+            controller: motivoCtrl,
+            maxLines: 3,
+            decoration: const InputDecoration(labelText: 'Motivo'),
+            validator: validateMotivo,
+          ),
+          if (state.error != null)
+            Padding(
+              padding: EdgeInsets.only(top: spacing.sm),
+              child: Text(
+                state.error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          SizedBox(height: spacing.lg),
+          ElevatedButton(
+            onPressed: state.isSending
+                ? null
+                : () async {
+                    if (formKey.currentState!.validate()) {
+                      await ref
+                          .read(cancelInvoiceControllerProvider.notifier)
+                          .submit(invoiceId, motivoCtrl.text);
+                    }
+                  },
+            child: state.isSending
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Confirmar anulación'),
+          ),
+        ],
+      );
+    }
+
+    Widget buildResult(CancelInvoiceResult result) {
+      return ResultCard(
+        result: result,
+        onView: () {
+          context.go('/notas-credito/${result.notaCreditoId}');
+        },
+        onClose: () => Navigator.of(context).pop(),
+      );
+    }
+
+    final isWide = MediaQuery.of(context).size.width >= 600;
+    final content = state.result != null
+        ? buildResult(state.result!)
+        : buildForm();
+
+    if (isWide) {
+      return AlertDialog(
+        title: const Text('Anular factura'),
+        content: Form(key: formKey, child: content),
+      );
+    }
+
+    return Dialog.fullscreen(
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Anular factura')),
+        body: Padding(
+          padding: EdgeInsets.all(spacing.md),
+          child: Form(key: formKey, child: content),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/invoicing/ui/result_card.dart
+++ b/lib/features/invoicing/ui/result_card.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../../invoices/data/models/cancel_result.dart';
+import '../../../core/theme/app_spacing.dart';
+import '../../../core/theme/app_radius.dart';
+
+class ResultCard extends StatelessWidget {
+  const ResultCard({
+    super.key,
+    required this.result,
+    required this.onView,
+    required this.onClose,
+  });
+
+  final CancelInvoiceResult result;
+  final VoidCallback onView;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final radius = Theme.of(context).extension<AppRadius>()!;
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(radius.md),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(spacing.md),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('NC generada',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            if (result.ncNumero != null)
+              Padding(
+                padding: EdgeInsets.only(top: spacing.sm),
+                child: Text('Número: ${result.ncNumero}'),
+              ),
+            Padding(
+              padding: EdgeInsets.only(top: spacing.sm),
+              child: Text('Estado SRI: ${result.estadoSri}'),
+            ),
+            if (result.mensajes.isNotEmpty)
+              Padding(
+                padding: EdgeInsets.only(top: spacing.sm),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: result.mensajes
+                      .map((m) => Text('${m.codigo}: ${m.detalle}'))
+                      .toList(),
+                ),
+              ),
+            SizedBox(height: spacing.md),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(onPressed: onView, child: const Text('Ver NC')),
+                SizedBox(width: spacing.sm),
+                ElevatedButton(onPressed: onClose, child: const Text('Cerrar')),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   json_annotation: ^4.8.1
   flutter_dotenv: ^5.0.2
   intl: ^0.18.0
+  uuid: ^4.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/cancel_invoice_controller_test.dart
+++ b/test/cancel_invoice_controller_test.dart
@@ -1,0 +1,46 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:punto_venta_front/features/invoicing/controllers/cancel_invoice_controller.dart';
+import 'package:punto_venta_front/features/invoices/data/invoices_repository.dart';
+
+class MockInvoicesRepository extends Mock implements InvoicesRepository {}
+
+void main() {
+  test('validateMotivo works', () {
+    expect(validateMotivo(''), isNotNull);
+    expect(validateMotivo('short'), isNotNull);
+    expect(validateMotivo('a' * 205), isNotNull);
+    expect(validateMotivo('motivo valido 123'), isNull);
+  });
+
+  test('handles 409 and 422 errors', () async {
+    final repo = MockInvoicesRepository();
+    when(() => repo.cancel(1, any())).thenThrow(DioException(
+      requestOptions: RequestOptions(path: ''),
+      response:
+          Response(requestOptions: RequestOptions(path: ''), statusCode: 409),
+    ));
+    final container = ProviderContainer(overrides: [
+      invoicesRepositoryProvider.overrideWithValue(repo),
+    ]);
+    final controller =
+        container.read(cancelInvoiceControllerProvider.notifier);
+    await controller.submit(1, 'motivo valido 123');
+    expect(container.read(cancelInvoiceControllerProvider).error,
+        'Factura ya anulada');
+
+    when(() => repo.cancel(1, any())).thenThrow(DioException(
+      requestOptions: RequestOptions(path: ''),
+      response: Response(
+          requestOptions: RequestOptions(path: ''),
+          statusCode: 422,
+          data: {'message': 'no permitido'}),
+    ));
+    await controller.submit(1, 'motivo valido 123');
+    expect(container.read(cancelInvoiceControllerProvider).error,
+        'no permitido');
+  });
+}

--- a/test/cancel_invoice_dialog_test.dart
+++ b/test/cancel_invoice_dialog_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:punto_venta_front/features/invoicing/ui/cancel_invoice_dialog.dart';
+import 'package:punto_venta_front/features/invoicing/controllers/cancel_invoice_controller.dart';
+import 'package:punto_venta_front/features/invoices/data/models/cancel_result.dart';
+import 'package:punto_venta_front/core/theme/app_spacing.dart';
+import 'package:punto_venta_front/core/theme/app_radius.dart';
+
+class FakeController extends CancelInvoiceController {
+  FakeController(Ref ref) : super(ref);
+
+  @override
+  Future<void> submit(int facturaId, String motivo) async {
+    state = state.copyWith(
+      result: CancelInvoiceResult(
+        facturaId: facturaId,
+        notaCreditoId: 2,
+        ncNumero: '001-001-0001',
+        estadoSri: 'enviada',
+      ),
+    );
+  }
+}
+
+void main() {
+  final theme = ThemeData(
+    extensions: const [
+      AppSpacing(xs: 4, sm: 8, md: 16, lg: 24, xl: 32, xxl: 40),
+      AppRadius(sm: 4, md: 8, lg: 16, pill: 50),
+    ],
+  );
+
+  testWidgets('shows result after submit', (tester) async {
+    final container = ProviderContainer(overrides: [
+      cancelInvoiceControllerProvider.overrideWith((ref) => FakeController(ref)),
+    ]);
+    await tester.pumpWidget(ProviderScope(
+      parent: container,
+      child: MaterialApp(
+        theme: theme,
+        home: MediaQuery(
+          data: const MediaQueryData(size: Size(800, 600)),
+          child: CancelInvoiceDialog(invoiceId: 1),
+        ),
+      ),
+    ));
+    await tester.enterText(find.byType(TextFormField), 'motivo valido 123');
+    await tester.tap(find.text('Confirmar anulación'));
+    await tester.pump();
+    expect(find.text('NC generada'), findsOneWidget);
+  });
+
+  testWidgets('uses fullscreen dialog on narrow screens', (tester) async {
+    final container = ProviderContainer(overrides: [
+      cancelInvoiceControllerProvider.overrideWith((ref) => FakeController(ref)),
+    ]);
+    await tester.pumpWidget(ProviderScope(
+      parent: container,
+      child: MaterialApp(
+        theme: theme,
+        home: MediaQuery(
+          data: const MediaQueryData(size: Size(400, 800)),
+          child: CancelInvoiceDialog(invoiceId: 1),
+        ),
+      ),
+    ));
+    expect(find.byType(AppBar), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add credit note cancellation dialog and controller
- expose cancel API, permission helper and wiring
- document invoice annulment flow and endpoints

## Testing
- `flutter format README.md api_registry.json lib/data/auth/auth_repository.dart lib/data/auth/user.dart lib/features/invoices/controllers/invoice_detail_state.dart lib/features/invoices/data/invoices_repository.dart lib/features/invoices/ui/invoice_detail_page.dart pubspec.yaml lib/features/invoices/data/models/cancel_result.dart lib/features/invoicing/controllers/cancel_invoice_controller.dart lib/features/invoicing/ui/cancel_invoice_dialog.dart lib/features/invoicing/ui/result_card.dart test/cancel_invoice_controller_test.dart test/cancel_invoice_dialog_test.dart test/invoices_repository_test.dart` *(fail: command not found)*
- `apt-get update` *(fail: The repository ... is not signed)*
- `flutter pub get` *(fail: command not found)*
- `flutter test` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cf4d74e4832f8663fef819be64c7