### PR TITLE
feat: add inventory movements

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,57 @@ La interfaz es responsive para móvil y web y todos los colores, espaciados y ra
 | GET | `/v1/stock?bodega_id=&producto_id=` | Consultar stock |
 | GET | `/v1/productos?search=&activo=true` | Autocompletar producto |
 
+## Frontend / Ajustes y Traspasos
+
+Pantalla para registrar ajustes de inventario y traspasos entre bodegas del mismo local.
+
+### Flujo
+
+Tabs **Ajuste** | **Traspaso**.
+
+#### Ajuste
+1. Seleccionar bodega y motivo.
+2. Agregar líneas con producto, cantidad (+/–) y costo opcional.
+3. Envío `POST /v1/inventario/ajuste` con `Idempotency-Key: AJU-<bodegaId>-<uuid>`.
+4. Éxito → limpiar formulario y mostrar confirmación.
+
+#### Traspaso
+1. Seleccionar bodegas de origen y destino (distintas).
+2. Agregar líneas con producto y cantidad (> 0).
+3. Envío `POST /v1/inventario/traspaso` con `Idempotency-Key: TRA-<origen>-<destino>-<uuid>`.
+4. Éxito → limpiar formulario y confirmar.
+
+### Validaciones
+- Ajuste: bodega y motivo requeridos; al menos una línea; cantidades no 0; costo ≥ 0.
+- Traspaso: origen y destino distintos; al menos una línea; cantidades > 0.
+
+### Endpoints usados
+
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| POST | `/v1/inventario/ajuste` | Crear ajuste de inventario |
+| POST | `/v1/inventario/traspaso` | Crear traspaso entre bodegas |
+| GET | `/v1/bodegas` | Listar bodegas del local |
+| GET | `/v1/productos?search=&activo=true` | Autocompletar producto |
+
+#### Ejemplo ajuste
+
+```json
+// Request
+{ "bodega_id":1, "motivo":"Rectificación", "items":[{"producto_id":10,"cantidad":-2,"costo":5}] }
+// Response
+{ "ajuste_id": 1 }
+```
+
+#### Ejemplo traspaso
+
+```json
+// Request
+{ "bodega_origen":1, "bodega_destino":2, "items":[{"producto_id":10,"cantidad":3}] }
+// Response
+{ "traspaso_id": 5 }
+```
+
 ## Guard Global
 
 El router redirige las rutas protegidas según el estado:

--- a/api_registry.json
+++ b/api_registry.json
@@ -64,4 +64,6 @@
     ,{"method":"PUT","path":"/v1/bodegas/{id}","name":"Editar bodega","module":"inventario","permission":"bodegas.editar"}
     ,{"method":"DELETE","path":"/v1/bodegas/{id}","name":"Eliminar bodega","module":"inventario","permission":"bodegas.eliminar"}
     ,{"method":"GET","path":"/v1/stock","name":"Consultar stock","module":"inventario","permission":"inventario.stock.ver"}
+    ,{"method":"POST","path":"/v1/inventario/ajuste","name":"Crear ajuste de inventario","module":"inventario","permission":"inventario.ajustes.crear"}
+    ,{"method":"POST","path":"/v1/inventario/traspaso","name":"Crear traspaso entre bodegas","module":"inventario","permission":"inventario.traspasos.crear"}
 ]

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -13,6 +13,7 @@ import '../../features/_placeholders_/selector_local_page.dart';
 import '../../features/products/ui/products_page.dart';
 import '../../features/invoices/ui/invoice_detail_page.dart';
 import '../../features/inventory/ui/inventory_page.dart';
+import '../../features/inventory/movements/ui/movements_page.dart';
 
 class GoRouterRefreshStream extends ChangeNotifier {
   GoRouterRefreshStream(Stream<dynamic> stream) {
@@ -55,6 +56,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/inventario',
         builder: (context, state) => const InventoryPage(),
+      ),
+      GoRoute(
+        path: '/inventario/movimientos',
+        builder: (context, state) => const InventoryMovementsPage(),
       ),
       GoRoute(
         path: '/productos',

--- a/lib/features/inventory/adjust/controllers/adjust_controller.dart
+++ b/lib/features/inventory/adjust/controllers/adjust_controller.dart
@@ -1,0 +1,102 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../common/line_item.dart';
+import '../data/adjust_repository.dart';
+import '../../../products/data/models/product.dart';
+import 'adjust_state.dart';
+
+final adjustControllerProvider =
+    StateNotifierProvider<AdjustController, AdjustState>((ref) {
+  return AdjustController(ref);
+});
+
+class AdjustController extends StateNotifier<AdjustState> {
+  AdjustController(this._ref) : super(const AdjustState());
+
+  final Ref _ref;
+
+  void addLine() {
+    state = state.copyWith(lines: [...state.lines, LineItem()]);
+  }
+
+  void removeLine(int index) {
+    final list = [...state.lines]..removeAt(index);
+    state = state.copyWith(lines: list);
+  }
+
+  void updateProduct(int index, Product product) {
+    final list = [...state.lines];
+    list[index].product = product;
+    state = state.copyWith(lines: list);
+  }
+
+  void updateQuantity(int index, double qty) {
+    final list = [...state.lines];
+    list[index].quantity = qty;
+    state = state.copyWith(lines: list);
+  }
+
+  void updateCost(int index, double? cost) {
+    final list = [...state.lines];
+    list[index].cost = cost;
+    state = state.copyWith(lines: list);
+  }
+
+  Future<bool> submit({required int bodegaId, required String motivo}) async {
+    final errors = <String, List<String>>{};
+    if (motivo.trim().isEmpty) {
+      errors['motivo'] = ['Requerido'];
+    }
+    if (state.lines.isEmpty) {
+      errors['items'] = ['Agregar al menos una línea'];
+    }
+    for (var i = 0; i < state.lines.length; i++) {
+      final l = state.lines[i];
+      if (l.product == null) {
+        errors['items[$i].producto_id'] = ['Requerido'];
+      }
+      if (l.quantity == 0) {
+        errors['items[$i].cantidad'] = ['No puede ser 0'];
+      }
+      if (l.cost != null && l.cost! < 0) {
+        errors['items[$i].costo'] = ['Debe ser >= 0'];
+      }
+    }
+    if (errors.isNotEmpty) {
+      state = state.copyWith(fieldErrors: errors);
+      return false;
+    }
+
+    state = state.copyWith(isSaving: true, fieldErrors: {});
+    final dto = {
+      'bodega_id': bodegaId,
+      'motivo': motivo,
+      'items': state.lines
+          .map((l) => {
+                'producto_id': l.product!.id,
+                'cantidad': l.quantity,
+                if (l.cost != null) 'costo': l.cost,
+              })
+          .toList(),
+    };
+    try {
+      await _ref.read(adjustRepositoryProvider).create(dto, bodegaId: bodegaId);
+      state = const AdjustState();
+      return true;
+    } on DioException catch (e) {
+      final details =
+          e.response?.data['error']?['details'] as Map<String, dynamic>?;
+      if (details != null) {
+        state = state.copyWith(
+            fieldErrors: details.map((k, v) => MapEntry(
+                k, (v as List).map((e) => e.toString()).toList())));
+      } else {
+        state = state.copyWith(error: e.message);
+      }
+      return false;
+    } finally {
+      state = state.copyWith(isSaving: false);
+    }
+  }
+}

--- a/lib/features/inventory/adjust/controllers/adjust_state.dart
+++ b/lib/features/inventory/adjust/controllers/adjust_state.dart
@@ -1,0 +1,27 @@
+import '../../common/line_item.dart';
+
+class AdjustState {
+  const AdjustState({
+    this.lines = const [],
+    this.isSaving = false,
+    this.error,
+    this.fieldErrors = const {},
+  });
+
+  final List<LineItem> lines;
+  final bool isSaving;
+  final String? error;
+  final Map<String, List<String>> fieldErrors;
+
+  AdjustState copyWith({
+    List<LineItem>? lines,
+    bool? isSaving,
+    String? error,
+    Map<String, List<String>>? fieldErrors,
+  }) => AdjustState(
+        lines: lines ?? this.lines,
+        isSaving: isSaving ?? this.isSaving,
+        error: error,
+        fieldErrors: fieldErrors ?? this.fieldErrors,
+      );
+}

--- a/lib/features/inventory/adjust/data/adjust_repository.dart
+++ b/lib/features/inventory/adjust/data/adjust_repository.dart
@@ -1,0 +1,29 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../core/network/dio_client.dart';
+
+final adjustRepositoryProvider = Provider<AdjustRepository>((ref) {
+  final dio = ref.read(dioProvider);
+  return AdjustRepository(dio);
+});
+
+class AdjustRepository {
+  AdjustRepository(this._dio);
+  final Dio _dio;
+  final _uuid = const Uuid();
+
+  Future<Map<String, dynamic>> create(
+    Map<String, dynamic> dto, {
+    required int bodegaId,
+  }) async {
+    final key = 'AJU-$bodegaId-${_uuid.v4()}';
+    final resp = await _dio.post(
+      '/v1/inventario/ajuste',
+      data: dto,
+      options: Options(headers: {'Idempotency-Key': key}),
+    );
+    return Map<String, dynamic>.from(resp.data as Map);
+  }
+}

--- a/lib/features/inventory/adjust/ui/adjust_page.dart
+++ b/lib/features/inventory/adjust/ui/adjust_page.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../core/theme/app_spacing.dart';
+import '../../bodegas/controllers/bodegas_controller.dart';
+import '../../bodegas/data/models/bodega.dart';
+import '../../common/lines_table.dart';
+import '../../common/reason_field.dart';
+import '../controllers/adjust_controller.dart';
+
+class AdjustPage extends HookConsumerWidget {
+  const AdjustPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final bodegasState = ref.watch(bodegasControllerProvider);
+    final adjustState = ref.watch(adjustControllerProvider);
+    final selectedBodega = useState<Bodega?>(null);
+    final motivoCtrl = useTextEditingController();
+
+    useEffect(() {
+      ref.read(bodegasControllerProvider.notifier).load();
+      return null;
+    }, const []);
+
+    final totalQty = adjustState.lines
+        .fold<double>(0, (prev, e) => prev + e.quantity);
+
+    return Padding(
+      padding: EdgeInsets.all(spacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          DropdownButton<Bodega>(
+            isExpanded: true,
+            value: selectedBodega.value,
+            hint: const Text('Seleccionar bodega'),
+            items: bodegasState.items
+                .map(
+                  (b) => DropdownMenuItem(
+                    value: b,
+                    child: Text(b.nombre),
+                  ),
+                )
+                .toList(),
+            onChanged: (b) => selectedBodega.value = b,
+          ),
+          SizedBox(height: spacing.md),
+          ReasonField(controller: motivoCtrl),
+          SizedBox(height: spacing.md),
+          Expanded(
+            child: SingleChildScrollView(
+              child: LinesTable(
+                lines: adjustState.lines,
+                onAdd: () =>
+                    ref.read(adjustControllerProvider.notifier).addLine(),
+                onRemove: (i) =>
+                    ref.read(adjustControllerProvider.notifier).removeLine(i),
+                onProduct: (i, p) => ref
+                    .read(adjustControllerProvider.notifier)
+                    .updateProduct(i, p),
+                onQuantity: (i, q) => ref
+                    .read(adjustControllerProvider.notifier)
+                    .updateQuantity(i, q),
+                onCost: (i, c) => ref
+                    .read(adjustControllerProvider.notifier)
+                    .updateCost(i, c),
+                showCost: true,
+                allowNegative: true,
+              ),
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('Total: $totalQty'),
+              ElevatedButton(
+                onPressed: adjustState.isSaving
+                    ? null
+                    : () async {
+                        if (selectedBodega.value == null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                                content: Text('Seleccione bodega')),
+                          );
+                          return;
+                        }
+                        final ok = await ref
+                            .read(adjustControllerProvider.notifier)
+                            .submit(
+                              bodegaId: selectedBodega.value!.id,
+                              motivo: motivoCtrl.text,
+                            );
+                        if (ok) {
+                          motivoCtrl.clear();
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Ajuste creado')),
+                          );
+                        }
+                      },
+                child: const Text('Guardar ajuste'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/inventory/common/line_item.dart
+++ b/lib/features/inventory/common/line_item.dart
@@ -1,0 +1,9 @@
+import '../../products/data/models/product.dart';
+
+class LineItem {
+  LineItem({this.product, this.quantity = 0, this.cost});
+
+  Product? product;
+  double quantity;
+  double? cost;
+}

--- a/lib/features/inventory/common/lines_table.dart
+++ b/lib/features/inventory/common/lines_table.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_spacing.dart';
+import '../../products/data/models/product.dart';
+import 'line_item.dart';
+import 'product_autocomplete_field.dart';
+import 'quantity_field.dart';
+
+class LinesTable extends StatelessWidget {
+  const LinesTable({
+    super.key,
+    required this.lines,
+    required this.onAdd,
+    required this.onRemove,
+    required this.onProduct,
+    required this.onQuantity,
+    this.onCost,
+    this.showCost = false,
+    this.allowNegative = false,
+  });
+
+  final List<LineItem> lines;
+  final VoidCallback onAdd;
+  final void Function(int) onRemove;
+  final void Function(int, Product) onProduct;
+  final void Function(int, double) onQuantity;
+  final void Function(int, double?)? onCost;
+  final bool showCost;
+  final bool allowNegative;
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    return Column(
+      children: [
+        for (var i = 0; i < lines.length; i++)
+          Padding(
+            padding: EdgeInsets.only(bottom: spacing.sm),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  flex: 4,
+                  child: ProductAutocompleteField(
+                    initialValue: lines[i].product,
+                    onSelected: (p) => onProduct(i, p),
+                  ),
+                ),
+                SizedBox(width: spacing.sm),
+                Expanded(
+                  flex: 2,
+                  child: QuantityField(
+                    value: lines[i].quantity,
+                    allowNegative: allowNegative,
+                    onChanged: (v) => onQuantity(i, v),
+                  ),
+                ),
+                if (showCost) ...[
+                  SizedBox(width: spacing.sm),
+                  Expanded(
+                    flex: 2,
+                    child: TextFormField(
+                      initialValue: lines[i].cost != null
+                          ? lines[i].cost.toString()
+                          : '',
+                      keyboardType:
+                          const TextInputType.numberWithOptions(decimal: true),
+                      decoration: const InputDecoration(hintText: 'Costo'),
+                      onChanged: (v) => onCost?.call(i, double.tryParse(v)),
+                    ),
+                  ),
+                ],
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: () => onRemove(i),
+                ),
+              ],
+            ),
+          ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: onAdd,
+            icon: const Icon(Icons.add),
+            label: const Text('Agregar línea'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/inventory/common/product_autocomplete_field.dart
+++ b/lib/features/inventory/common/product_autocomplete_field.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../stock/data/stock_repository.dart';
+import '../../products/data/models/product.dart';
+
+class ProductAutocompleteField extends HookConsumerWidget {
+  const ProductAutocompleteField({
+    super.key,
+    this.initialValue,
+    required this.onSelected,
+  });
+
+  final Product? initialValue;
+  final ValueChanged<Product> onSelected;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ctrl = useTextEditingController();
+    final debounce = useRef<Timer?>(null);
+
+    useEffect(() {
+      if (initialValue != null) {
+        ctrl.text = '${initialValue!.codigo} - ${initialValue!.nombre}';
+      }
+      return null;
+    }, const []);
+
+    return Autocomplete<Product>(
+      displayStringForOption: (p) => '${p.codigo} - ${p.nombre}',
+      optionsBuilder: (text) {
+        final query = text.text;
+        if (query.length < 2) return const Iterable<Product>.empty();
+        debounce.value?.cancel();
+        debounce.value = Timer(const Duration(milliseconds: 300), () {});
+        final result = ref.watch(productsSearchProvider(query)).value ?? [];
+        return result;
+      },
+      onSelected: (p) {
+        ctrl.text = '${p.codigo} - ${p.nombre}';
+        onSelected(p);
+      },
+      fieldViewBuilder: (context, textCtrl, focus, onFieldSubmitted) {
+        textCtrl.value = ctrl.value;
+        return TextField(
+          controller: textCtrl,
+          focusNode: focus,
+          decoration: const InputDecoration(hintText: 'Producto'),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/inventory/common/quantity_field.dart
+++ b/lib/features/inventory/common/quantity_field.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class QuantityField extends StatelessWidget {
+  const QuantityField({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.allowNegative = false,
+  });
+
+  final double value;
+  final ValueChanged<double> onChanged;
+  final bool allowNegative;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      initialValue: value == 0 ? '' : value.toString(),
+      keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: true),
+      decoration: const InputDecoration(hintText: 'Cantidad'),
+      onChanged: (v) {
+        final parsed = double.tryParse(v) ?? 0;
+        if (!allowNegative && parsed < 0) {
+          onChanged(0);
+        } else {
+          onChanged(parsed);
+        }
+      },
+    );
+  }
+}

--- a/lib/features/inventory/common/reason_field.dart
+++ b/lib/features/inventory/common/reason_field.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ReasonField extends StatelessWidget {
+  const ReasonField({super.key, required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      maxLines: 3,
+      decoration: const InputDecoration(
+        labelText: 'Motivo',
+      ),
+    );
+  }
+}

--- a/lib/features/inventory/movements/ui/movements_page.dart
+++ b/lib/features/inventory/movements/ui/movements_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import '../../adjust/ui/adjust_page.dart';
+import '../../transfer/ui/transfer_page.dart';
+
+class InventoryMovementsPage extends StatelessWidget {
+  const InventoryMovementsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Movimientos'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Ajuste'),
+              Tab(text: 'Traspaso'),
+            ],
+          ),
+        ),
+        body: const TabBarView(
+          children: [
+            AdjustPage(),
+            TransferPage(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/inventory/transfer/controllers/transfer_controller.dart
+++ b/lib/features/inventory/transfer/controllers/transfer_controller.dart
@@ -1,0 +1,94 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../common/line_item.dart';
+import '../data/transfer_repository.dart';
+import '../../../products/data/models/product.dart';
+import 'transfer_state.dart';
+
+final transferControllerProvider =
+    StateNotifierProvider<TransferController, TransferState>((ref) {
+  return TransferController(ref);
+});
+
+class TransferController extends StateNotifier<TransferState> {
+  TransferController(this._ref) : super(const TransferState());
+
+  final Ref _ref;
+
+  void addLine() {
+    state = state.copyWith(lines: [...state.lines, LineItem()]);
+  }
+
+  void removeLine(int index) {
+    final list = [...state.lines]..removeAt(index);
+    state = state.copyWith(lines: list);
+  }
+
+  void updateProduct(int index, Product product) {
+    final list = [...state.lines];
+    list[index].product = product;
+    state = state.copyWith(lines: list);
+  }
+
+  void updateQuantity(int index, double qty) {
+    final list = [...state.lines];
+    list[index].quantity = qty;
+    state = state.copyWith(lines: list);
+  }
+
+  Future<bool> submit({required int origen, required int destino}) async {
+    final errors = <String, List<String>>{};
+    if (origen == destino) {
+      errors['bodegas'] = ['Origen y destino deben ser distintos'];
+    }
+    if (state.lines.isEmpty) {
+      errors['items'] = ['Agregar al menos una línea'];
+    }
+    for (var i = 0; i < state.lines.length; i++) {
+      final l = state.lines[i];
+      if (l.product == null) {
+        errors['items[$i].producto_id'] = ['Requerido'];
+      }
+      if (l.quantity <= 0) {
+        errors['items[$i].cantidad'] = ['Debe ser > 0'];
+      }
+    }
+    if (errors.isNotEmpty) {
+      state = state.copyWith(fieldErrors: errors);
+      return false;
+    }
+
+    state = state.copyWith(isSaving: true, fieldErrors: {});
+    final dto = {
+      'bodega_origen': origen,
+      'bodega_destino': destino,
+      'items': state.lines
+          .map((l) => {
+                'producto_id': l.product!.id,
+                'cantidad': l.quantity,
+              })
+          .toList(),
+    };
+    try {
+      await _ref
+          .read(transferRepositoryProvider)
+          .create(dto, origen: origen, destino: destino);
+      state = const TransferState();
+      return true;
+    } on DioException catch (e) {
+      final details =
+          e.response?.data['error']?['details'] as Map<String, dynamic>?;
+      if (details != null) {
+        state = state.copyWith(
+            fieldErrors: details.map((k, v) => MapEntry(
+                k, (v as List).map((e) => e.toString()).toList())));
+      } else {
+        state = state.copyWith(error: e.message);
+      }
+      return false;
+    } finally {
+      state = state.copyWith(isSaving: false);
+    }
+  }
+}

--- a/lib/features/inventory/transfer/controllers/transfer_state.dart
+++ b/lib/features/inventory/transfer/controllers/transfer_state.dart
@@ -1,0 +1,27 @@
+import '../../common/line_item.dart';
+
+class TransferState {
+  const TransferState({
+    this.lines = const [],
+    this.isSaving = false,
+    this.error,
+    this.fieldErrors = const {},
+  });
+
+  final List<LineItem> lines;
+  final bool isSaving;
+  final String? error;
+  final Map<String, List<String>> fieldErrors;
+
+  TransferState copyWith({
+    List<LineItem>? lines,
+    bool? isSaving,
+    String? error,
+    Map<String, List<String>>? fieldErrors,
+  }) => TransferState(
+        lines: lines ?? this.lines,
+        isSaving: isSaving ?? this.isSaving,
+        error: error,
+        fieldErrors: fieldErrors ?? this.fieldErrors,
+      );
+}

--- a/lib/features/inventory/transfer/data/transfer_repository.dart
+++ b/lib/features/inventory/transfer/data/transfer_repository.dart
@@ -1,0 +1,30 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../core/network/dio_client.dart';
+
+final transferRepositoryProvider = Provider<TransferRepository>((ref) {
+  final dio = ref.read(dioProvider);
+  return TransferRepository(dio);
+});
+
+class TransferRepository {
+  TransferRepository(this._dio);
+  final Dio _dio;
+  final _uuid = const Uuid();
+
+  Future<Map<String, dynamic>> create(
+    Map<String, dynamic> dto, {
+    required int origen,
+    required int destino,
+  }) async {
+    final key = 'TRA-$origen-$destino-${_uuid.v4()}';
+    final resp = await _dio.post(
+      '/v1/inventario/traspaso',
+      data: dto,
+      options: Options(headers: {'Idempotency-Key': key}),
+    );
+    return Map<String, dynamic>.from(resp.data as Map);
+  }
+}

--- a/lib/features/inventory/transfer/ui/transfer_page.dart
+++ b/lib/features/inventory/transfer/ui/transfer_page.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../core/theme/app_spacing.dart';
+import '../../bodegas/controllers/bodegas_controller.dart';
+import '../../bodegas/data/models/bodega.dart';
+import '../../common/lines_table.dart';
+import '../controllers/transfer_controller.dart';
+
+class TransferPage extends HookConsumerWidget {
+  const TransferPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final bodegasState = ref.watch(bodegasControllerProvider);
+    final transferState = ref.watch(transferControllerProvider);
+    final origen = useState<Bodega?>(null);
+    final destino = useState<Bodega?>(null);
+
+    useEffect(() {
+      ref.read(bodegasControllerProvider.notifier).load();
+      return null;
+    }, const []);
+
+    return Padding(
+      padding: EdgeInsets.all(spacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: DropdownButton<Bodega>(
+                  isExpanded: true,
+                  value: origen.value,
+                  hint: const Text('Origen'),
+                  items: bodegasState.items
+                      .map((b) => DropdownMenuItem(value: b, child: Text(b.nombre)))
+                      .toList(),
+                  onChanged: (b) => origen.value = b,
+                ),
+              ),
+              SizedBox(width: spacing.md),
+              Expanded(
+                child: DropdownButton<Bodega>(
+                  isExpanded: true,
+                  value: destino.value,
+                  hint: const Text('Destino'),
+                  items: bodegasState.items
+                      .map((b) => DropdownMenuItem(value: b, child: Text(b.nombre)))
+                      .toList(),
+                  onChanged: (b) => destino.value = b,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: spacing.md),
+          Expanded(
+            child: SingleChildScrollView(
+              child: LinesTable(
+                lines: transferState.lines,
+                onAdd: () =>
+                    ref.read(transferControllerProvider.notifier).addLine(),
+                onRemove: (i) =>
+                    ref.read(transferControllerProvider.notifier).removeLine(i),
+                onProduct: (i, p) => ref
+                    .read(transferControllerProvider.notifier)
+                    .updateProduct(i, p),
+                onQuantity: (i, q) => ref
+                    .read(transferControllerProvider.notifier)
+                    .updateQuantity(i, q),
+                showCost: false,
+                allowNegative: false,
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: ElevatedButton(
+              onPressed: transferState.isSaving
+                  ? null
+                  : () async {
+                      if (origen.value == null || destino.value == null) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Seleccione bodegas')),
+                        );
+                        return;
+                      }
+                      final ok = await ref
+                          .read(transferControllerProvider.notifier)
+                          .submit(
+                              origen: origen.value!.id,
+                              destino: destino.value!.id);
+                      if (ok) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Traspaso creado')),
+                        );
+                      }
+                    },
+              child: const Text('Guardar traspaso'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/adjust_controller_test.dart
+++ b/test/adjust_controller_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:punto_venta_front/features/inventory/adjust/controllers/adjust_controller.dart';
+import 'package:punto_venta_front/features/inventory/adjust/data/adjust_repository.dart';
+import 'package:punto_venta_front/features/products/data/models/product.dart';
+
+class FakeAdjustRepository implements AdjustRepository {
+  Map<String, dynamic>? lastDto;
+
+  @override
+  Future<Map<String, dynamic>> create(Map<String, dynamic> dto,
+      {required int bodegaId}) async {
+    lastDto = dto;
+    return {'ajuste_id': 1};
+  }
+}
+
+void main() {
+  test('payload por línea y validaciones', () async {
+    final fakeRepo = FakeAdjustRepository();
+    final container = ProviderContainer(overrides: [
+      adjustRepositoryProvider.overrideWithValue(fakeRepo),
+    ]);
+    final controller = container.read(adjustControllerProvider.notifier);
+    controller.addLine();
+    controller.updateProduct(
+      0,
+      Product(
+        id: 1,
+        codigo: 'P1',
+        nombre: 'Prod',
+        descripcion: null,
+        categoriaId: 1,
+        categoriaNombre: null,
+        unidadId: 1,
+        unidadCodigo: null,
+        impuestoId: 1,
+        impuestoCodigo: null,
+        precio: 0,
+        activo: true,
+      ),
+    );
+    controller.updateQuantity(0, -2);
+    controller.updateCost(0, 5);
+    final ok = await controller.submit(bodegaId: 1, motivo: 'Test');
+    expect(ok, true);
+    expect(fakeRepo.lastDto?['items'], [
+      {'producto_id': 1, 'cantidad': -2, 'costo': 5}
+    ]);
+  });
+
+  test('reglas de validacion', () async {
+    final fakeRepo = FakeAdjustRepository();
+    final container = ProviderContainer(overrides: [
+      adjustRepositoryProvider.overrideWithValue(fakeRepo),
+    ]);
+    final controller = container.read(adjustControllerProvider.notifier);
+    final ok = await controller.submit(bodegaId: 1, motivo: '');
+    expect(ok, false);
+    expect(controller.state.fieldErrors.containsKey('motivo'), true);
+  });
+}

--- a/test/adjust_page_test.dart
+++ b/test/adjust_page_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:punto_venta_front/features/inventory/adjust/ui/adjust_page.dart';
+import 'package:punto_venta_front/features/inventory/bodegas/data/bodegas_repository.dart';
+import 'package:punto_venta_front/features/inventory/bodegas/data/models/bodega.dart';
+
+class FakeBodegasRepository implements BodegasRepository {
+  @override
+  Future<Bodega> create(Map<String, dynamic> dto) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> delete(int id) async {}
+
+  @override
+  Future<List<Bodega>> list({Map<String, dynamic>? params}) async => [
+        Bodega(id: 1, codigo: 'B1', nombre: 'Bodega', zona: null, activo: true)
+      ];
+
+  @override
+  Future<Bodega> update(int id, Map<String, dynamic> dto) async =>
+      throw UnimplementedError();
+}
+
+void main() {
+  testWidgets('agregar y eliminar líneas', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          bodegasRepositoryProvider.overrideWithValue(FakeBodegasRepository()),
+        ],
+        child: const MaterialApp(home: Scaffold(body: AdjustPage())),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.delete), findsNothing);
+    await tester.tap(find.text('Agregar línea'));
+    await tester.pump();
+    expect(find.byIcon(Icons.delete), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.delete));
+    await tester.pump();
+    expect(find.byIcon(Icons.delete), findsNothing);
+  });
+}

--- a/test/transfer_controller_test.dart
+++ b/test/transfer_controller_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:punto_venta_front/features/inventory/transfer/controllers/transfer_controller.dart';
+import 'package:punto_venta_front/features/inventory/transfer/data/transfer_repository.dart';
+import 'package:punto_venta_front/features/products/data/models/product.dart';
+
+class FakeTransferRepository implements TransferRepository {
+  Map<String, dynamic>? lastDto;
+
+  @override
+  Future<Map<String, dynamic>> create(Map<String, dynamic> dto,
+      {required int origen, required int destino}) async {
+    lastDto = dto;
+    return {'traspaso_id': 1};
+  }
+}
+
+void main() {
+  test('origen distinto y cantidades > 0', () async {
+    final repo = FakeTransferRepository();
+    final container = ProviderContainer(overrides: [
+      transferRepositoryProvider.overrideWithValue(repo),
+    ]);
+    final controller = container.read(transferControllerProvider.notifier);
+    controller.addLine();
+    controller.updateProduct(
+        0,
+        Product(
+            id: 1,
+            codigo: 'P1',
+            nombre: 'Prod',
+            descripcion: null,
+            categoriaId: 1,
+            categoriaNombre: null,
+            unidadId: 1,
+            unidadCodigo: null,
+            impuestoId: 1,
+            impuestoCodigo: null,
+            precio: 0,
+            activo: true));
+    controller.updateQuantity(0, 3);
+    final ok = await controller.submit(origen: 1, destino: 2);
+    expect(ok, true);
+    expect(repo.lastDto?['items'], [
+      {'producto_id': 1, 'cantidad': 3}
+    ]);
+  });
+
+  test('valida bodegas distintas', () async {
+    final repo = FakeTransferRepository();
+    final container = ProviderContainer(overrides: [
+      transferRepositoryProvider.overrideWithValue(repo),
+    ]);
+    final controller = container.read(transferControllerProvider.notifier);
+    final ok = await controller.submit(origen: 1, destino: 1);
+    expect(ok, false);
+    expect(controller.state.fieldErrors.containsKey('bodegas'), true);
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable widgets for inventory line entry
- support inventory adjustments and warehouse transfers
- document new flows and register APIs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d437cc3c832fad298acfe3e4d465