### PR TITLE
feat: add purchases and cxp skeleton

### DIFF
--- a/api_registry.json
+++ b/api_registry.json
@@ -66,4 +66,11 @@
     ,{"method":"GET","path":"/v1/stock","name":"Consultar stock","module":"inventario","permission":"inventario.stock.ver"}
     ,{"method":"POST","path":"/v1/inventario/ajuste","name":"Crear ajuste de inventario","module":"inventario","permission":"inventario.ajustes.crear"}
     ,{"method":"POST","path":"/v1/inventario/traspaso","name":"Crear traspaso entre bodegas","module":"inventario","permission":"inventario.traspasos.crear"}
+    ,{"method":"GET","path":"/v1/compras","name":"Listar compras","module":"compras","permission":"compras.ver"},
+    {"method":"POST","path":"/v1/compras","name":"Crear compra (borrador)","module":"compras","permission":"compras.crear"},
+    {"method":"PUT","path":"/v1/compras/{id}","name":"Editar compra (borrador)","module":"compras","permission":"compras.editar"},
+    {"method":"POST","path":"/v1/compras/{id}/aprobar","name":"Aprobar compra","module":"compras","permission":"compras.aprobar"},
+    {"method":"GET","path":"/v1/cxp","name":"Listar CxP por proveedor","module":"cxp","permission":"cxp.ver"},
+    {"method":"POST","path":"/v1/pagos-proveedor","name":"Registrar pago a proveedor","module":"cxp","permission":"pagos_proveedor.crear"},
+    {"method":"GET","path":"/v1/proveedores","name":"Buscar proveedores","module":"proveedores","permission":"proveedores.ver"}
 ]

--- a/lib/features/ap/cxp/controllers/payment_controller.dart
+++ b/lib/features/ap/cxp/controllers/payment_controller.dart
@@ -1,0 +1,11 @@
+class PaymentController {
+  bool canPay({required double saldo, required double monto}) {
+    if (monto < 0.01) {
+      return false;
+    }
+    if (monto > saldo) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/lib/features/purchase/controllers/purchase_controller.dart
+++ b/lib/features/purchase/controllers/purchase_controller.dart
@@ -1,0 +1,17 @@
+import '../data/models/purchase.dart';
+
+class PurchaseController {
+  PurchaseController({List<PurchaseItem>? items})
+      : items = items ?? [];
+
+  final List<PurchaseItem> items;
+
+  bool get canApprove => items.isNotEmpty;
+
+  void approve() {
+    if (items.isEmpty) {
+      throw StateError('No hay líneas para aprobar');
+    }
+    // Aquí se llamaría al repositorio para aprobar la compra.
+  }
+}

--- a/lib/features/purchase/data/models/purchase.dart
+++ b/lib/features/purchase/data/models/purchase.dart
@@ -1,0 +1,54 @@
+class PurchaseItem {
+  PurchaseItem({
+    required this.productoId,
+    required this.cantidad,
+    required this.costo,
+    this.impuesto,
+  });
+
+  final int productoId;
+  final double cantidad;
+  final double costo;
+  final double? impuesto; // e.g. 0.12 for 12%
+
+  double get subtotal => cantidad * costo;
+
+  double get iva => impuesto != null ? subtotal * impuesto! : 0;
+
+  double get total => subtotal + iva;
+
+  Map<String, dynamic> toJson() => {
+        'producto_id': productoId,
+        'cantidad': cantidad,
+        'costo': costo,
+        if (impuesto != null) 'impuesto': impuesto,
+      };
+}
+
+class Purchase {
+  Purchase({
+    required this.proveedorId,
+    required this.bodegaId,
+    required this.fecha,
+    List<PurchaseItem>? items,
+  }) : items = items ?? [];
+
+  final int proveedorId;
+  final int bodegaId;
+  final DateTime fecha;
+  final List<PurchaseItem> items;
+
+  double get subtotal =>
+      items.fold(0, (sum, item) => sum + item.subtotal);
+
+  double get iva => items.fold(0, (sum, item) => sum + item.iva);
+
+  double get total => subtotal + iva;
+
+  Map<String, dynamic> toJson() => {
+        'proveedor_id': proveedorId,
+        'bodega_id': bodegaId,
+        'fecha': fecha.toIso8601String().split('T').first,
+        'items': items.map((e) => e.toJson()).toList(),
+      };
+}

--- a/test/payment_controller_test.dart
+++ b/test/payment_controller_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:punto_venta_front/features/ap/cxp/controllers/payment_controller.dart';
+
+void main() {
+  group('PaymentController', () {
+    test('rejects amount greater than balance', () {
+      final controller = PaymentController();
+      expect(controller.canPay(saldo: 100, monto: 150), isFalse);
+    });
+
+    test('rejects amount less than 0.01', () {
+      final controller = PaymentController();
+      expect(controller.canPay(saldo: 100, monto: 0), isFalse);
+    });
+
+    test('accepts valid amount', () {
+      final controller = PaymentController();
+      expect(controller.canPay(saldo: 100, monto: 50), isTrue);
+    });
+  });
+}

--- a/test/purchase_controller_test.dart
+++ b/test/purchase_controller_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:punto_venta_front/features/purchase/controllers/purchase_controller.dart';
+import 'package:punto_venta_front/features/purchase/data/models/purchase.dart';
+
+void main() {
+  group('Purchase totals', () {
+    test('calculates subtotal, iva and total', () {
+      final purchase = Purchase(
+        proveedorId: 1,
+        bodegaId: 1,
+        fecha: DateTime(2025, 8, 18),
+        items: [
+          PurchaseItem(
+            productoId: 1,
+            cantidad: 10,
+            costo: 3.20,
+            impuesto: 0.12,
+          ),
+        ],
+      );
+      expect(purchase.subtotal, 32.0);
+      expect(purchase.iva, 3.84);
+      expect(purchase.total, 35.84);
+    });
+  });
+
+  group('PurchaseController', () {
+    test('cannot approve without lines', () {
+      final controller = PurchaseController();
+      expect(controller.canApprove, isFalse);
+      expect(controller.approve, throwsStateError);
+    });
+
+    test('can approve with at least one line', () {
+      final controller = PurchaseController(
+        items: [
+          PurchaseItem(
+            productoId: 1,
+            cantidad: 1,
+            costo: 1,
+          ),
+        ],
+      );
+      expect(controller.canApprove, isTrue);
+      expect(controller.approve, isNot(throwsStateError));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add purchase model with totals and approval guard
- add payment controller to validate supplier payments
- document purchases and CxP flows and register new API endpoints

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d621537c832f98e962c1024a1ce2