### PR TITLE
feat(crm): clientes y proveedores crud

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,39 @@ Módulo administrativo para gestionar usuarios del local actual y sus roles. Dis
 
 El listado utiliza los mismos componentes para móvil y web; en pantallas estrechas se muestra como lista y en escritorios como tabla compacta. Todos los estilos provienen de los tokens de tema (`AppColors`, `AppSpacing`, `AppRadius`).
 
+## Frontend / Clientes y Proveedores
+
+Módulo para administrar clientes y proveedores del punto de venta. La pantalla posee pestañas **Clientes** y **Proveedores** con buscador, filtro por estado y botón **Nuevo**.
+
+### Flujos
+
+- Listar con `GET /v1/clientes` y `GET /v1/proveedores` usando parámetros `search`, `activo`, `page` y `per_page`.
+- Crear envía `POST /v1/clientes` o `POST /v1/proveedores`.
+- Editar usa `PUT /v1/clientes/{id}` o `PUT /v1/proveedores/{id}`.
+- Eliminar realiza `DELETE /v1/clientes/{id}` o `DELETE /v1/proveedores/{id}`; el **409** muestra "En uso".
+- El detalle se muestra en diálogo con acciones **Editar** y **Eliminar**.
+
+### Validaciones
+
+- Campos requeridos según entidad.
+- Email con formato válido.
+- Identificación/RUC únicos; los errores **422** se mapean al formulario.
+
+### Endpoints usados
+
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| GET | `/v1/clientes` | Listar clientes |
+| POST | `/v1/clientes` | Crear cliente |
+| PUT | `/v1/clientes/{id}` | Editar cliente |
+| DELETE | `/v1/clientes/{id}` | Eliminar cliente |
+| GET | `/v1/proveedores` | Listar proveedores |
+| POST | `/v1/proveedores` | Crear proveedor |
+| PUT | `/v1/proveedores/{id}` | Editar proveedor |
+| DELETE | `/v1/proveedores/{id}` | Eliminar proveedor |
+
+La interfaz es responsive: lista en móvil y tabla compacta en web, reutilizando `AppSpacing` y demás extensiones del tema.
+
 ## Frontend / Catálogos
 
 Pantalla para administrar catálogos básicos del punto de venta: Impuestos, Unidades, Métodos de pago y Categorías.

--- a/lib/features/crm/customers/controllers/customers_controller.dart
+++ b/lib/features/crm/customers/controllers/customers_controller.dart
@@ -29,20 +29,23 @@ class CustomersController extends StateNotifier<CustomersState> {
   }
 
   Future<Customer?> create(Map<String, dynamic> dto) async {
+    final repo = _ref.read(customersRepositoryProvider);
     try {
-      final repo = _ref.read(customersRepositoryProvider);
       final c = await repo.create(dto);
       state = state.copyWith(customers: [...state.customers, c]);
       return c;
     } on DioException catch (e) {
       state = state.copyWith(error: e.message);
+      if (e.response?.statusCode == 422) {
+        throw repo.map422(e);
+      }
       rethrow;
     }
   }
 
   Future<Customer?> update(int id, Map<String, dynamic> dto) async {
+    final repo = _ref.read(customersRepositoryProvider);
     try {
-      final repo = _ref.read(customersRepositoryProvider);
       final c = await repo.update(id, dto);
       final idx = state.customers.indexWhere((e) => e.id == id);
       if (idx != -1) {
@@ -53,6 +56,9 @@ class CustomersController extends StateNotifier<CustomersState> {
       return c;
     } on DioException catch (e) {
       state = state.copyWith(error: e.message);
+      if (e.response?.statusCode == 422) {
+        throw repo.map422(e);
+      }
       rethrow;
     }
   }

--- a/lib/features/crm/customers/ui/customer_detail.dart
+++ b/lib/features/crm/customers/ui/customer_detail.dart
@@ -12,7 +12,12 @@ class CustomerDetail extends StatelessWidget {
   Widget build(BuildContext context) {
     final spacing = Theme.of(context).extension<AppSpacing>()!;
     return AlertDialog(
-      title: Text(customer.nombreRazon),
+      title: Row(
+        children: [
+          Expanded(child: Text(customer.nombreRazon)),
+          Chip(label: Text(customer.activo ? 'Activo' : 'Inactivo')),
+        ],
+      ),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -30,6 +35,14 @@ class CustomerDetail extends StatelessWidget {
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: const Text('Cerrar'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, 'delete'),
+          child: const Text('Eliminar'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, 'edit'),
+          child: const Text('Editar'),
         ),
       ],
     );

--- a/lib/features/crm/customers/ui/customer_form.dart
+++ b/lib/features/crm/customers/ui/customer_form.dart
@@ -67,6 +67,13 @@ class _CustomerFormState extends State<CustomerForm> {
               TextFormField(
                 controller: _email,
                 decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) {
+                  if (v == null || v.isEmpty) return null;
+                  final emailReg =
+                      RegExp(r'^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$');
+                  if (!emailReg.hasMatch(v)) return 'Email inválido';
+                  return null;
+                },
               ),
               SizedBox(height: spacing.sm),
               TextFormField(

--- a/lib/features/crm/customers/ui/customers_page.dart
+++ b/lib/features/crm/customers/ui/customers_page.dart
@@ -20,13 +20,17 @@ class CustomersPage extends HookConsumerWidget {
     final state = ref.watch(customersControllerProvider);
     final search = useTextEditingController();
     final timer = useRef<Timer?>(null);
+    final filter = useState<bool?>(null);
 
     useEffect(() {
       controller.load();
       void listener() {
         timer.value?.cancel();
         timer.value = Timer(const Duration(milliseconds: 400), () {
-          controller.load(params: {'search': search.text});
+          controller.load(params: {
+            'search': search.text,
+            if (filter.value != null) 'activo': filter.value! ? 1 : 0,
+          });
         });
       }
 
@@ -35,7 +39,7 @@ class CustomersPage extends HookConsumerWidget {
         timer.value?.cancel();
         search.removeListener(listener);
       };
-    }, []);
+    }, [filter.value]);
 
     Future<void> openForm([Customer? customer]) async {
       final data = await showDialog<Map<String, dynamic>>(
@@ -43,48 +47,167 @@ class CustomersPage extends HookConsumerWidget {
         builder: (_) => CustomerForm(initial: customer),
       );
       if (data != null) {
-        if (customer == null) {
-          await controller.create(data);
-        } else {
-          await controller.update(customer.id, data);
+        try {
+          if (customer == null) {
+            await controller.create(data);
+          } else {
+            await controller.update(customer.id, data);
+          }
+        } on Map<String, List<String>> catch (errors) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(errors.values.first.first)),
+          );
         }
       }
     }
 
+    Future<void> showDetail(Customer c) async {
+      final action = await showDialog<String>(
+        context: context,
+        builder: (_) => CustomerDetail(customer: c),
+      );
+      if (action == 'edit') {
+        await openForm(c);
+      } else if (action == 'delete') {
+        final confirm = await showDialog<bool>(
+              context: context,
+              builder: (ctx) => AlertDialog(
+                title: const Text('Confirmar'),
+                content: const Text('¿Eliminar cliente?'),
+                actions: [
+                  TextButton(
+                      onPressed: () => Navigator.pop(ctx, false),
+                      child: const Text('No')),
+                  FilledButton(
+                      onPressed: () => Navigator.pop(ctx, true),
+                      child: const Text('Sí')),
+                ],
+              ),
+            ) ??
+            false;
+        if (confirm) {
+          await controller.remove(c.id);
+        }
+      }
+    }
+
+    Widget buildList() {
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          final items = state.customers;
+          if (constraints.maxWidth < 600) {
+            return ListView.builder(
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                final c = items[index];
+                return ListTile(
+                  title: Text(c.nombreRazon),
+                  subtitle: Text(c.email ?? c.telefono ?? ''),
+                  trailing: Text(c.activo ? 'Activo' : 'Inactivo'),
+                  onTap: () => showDetail(c),
+                );
+              },
+            );
+          }
+          return DataTable(
+            columns: const [
+              DataColumn(label: Text('Nombre/Razón')),
+              DataColumn(label: Text('Identificación')),
+              DataColumn(label: Text('Email/Teléfono')),
+              DataColumn(label: Text('Estado')),
+              DataColumn(label: Text('Acciones')),
+            ],
+            rows: [
+              for (final c in items)
+                DataRow(cells: [
+                  DataCell(Text(c.nombreRazon)),
+                  DataCell(Text(c.identificacion ?? '')),
+                  DataCell(Text(c.email ?? c.telefono ?? '')),
+                  DataCell(Text(c.activo ? 'Activo' : 'Inactivo')),
+                  DataCell(Row(
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.visibility),
+                        onPressed: () => showDetail(c),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.edit),
+                        onPressed: () => openForm(c),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: () async {
+                          final confirm = await showDialog<bool>(
+                                context: context,
+                                builder: (ctx) => AlertDialog(
+                                  title: const Text('Confirmar'),
+                                  content:
+                                      const Text('¿Eliminar cliente?'),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Navigator.pop(ctx, false),
+                                      child: const Text('No'),
+                                    ),
+                                    FilledButton(
+                                      onPressed: () => Navigator.pop(ctx, true),
+                                      child: const Text('Sí'),
+                                    ),
+                                  ],
+                                ),
+                              ) ??
+                              false;
+                          if (confirm) {
+                            await controller.remove(c.id);
+                          }
+                        },
+                      ),
+                    ],
+                  )),
+                ])
+            ],
+          );
+        },
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('Clientes')),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => openForm(),
-        child: const Icon(Icons.add),
-      ),
       body: Column(
         children: [
           Padding(
             padding: EdgeInsets.all(spacing.sm),
-            child: TextField(
-              controller: search,
-              decoration: const InputDecoration(hintText: 'Buscar'),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: search,
+                    decoration: const InputDecoration(hintText: 'Buscar'),
+                  ),
+                ),
+                SizedBox(width: spacing.sm),
+                DropdownButton<bool?>(
+                  value: filter.value,
+                  hint: const Text('Estado'),
+                  onChanged: (v) => filter.value = v,
+                  items: const [
+                    DropdownMenuItem(value: null, child: Text('Todos')),
+                    DropdownMenuItem(value: true, child: Text('Activos')),
+                    DropdownMenuItem(value: false, child: Text('Inactivos')),
+                  ],
+                ),
+                SizedBox(width: spacing.sm),
+                FilledButton.icon(
+                  onPressed: () => openForm(),
+                  icon: const Icon(Icons.add),
+                  label: const Text('Nuevo'),
+                ),
+              ],
             ),
           ),
           Expanded(
             child: state.isLoading
                 ? const Center(child: CircularProgressIndicator())
-                : ListView.builder(
-                    itemCount: state.customers.length,
-                    itemBuilder: (context, index) {
-                      final c = state.customers[index];
-                      return ListTile(
-                        title: Text(c.nombreRazon),
-                        subtitle: Text(c.email ?? c.telefono ?? ''),
-                        trailing: Text(c.activo ? 'Activo' : 'Inactivo'),
-                        onTap: () => showDialog(
-                          context: context,
-                          builder: (_) => CustomerDetail(customer: c),
-                        ),
-                        onLongPress: () => openForm(c),
-                      );
-                    },
-                  ),
+                : buildList(),
           ),
         ],
       ),

--- a/lib/features/proc/vendors/controllers/vendors_controller.dart
+++ b/lib/features/proc/vendors/controllers/vendors_controller.dart
@@ -29,20 +29,23 @@ class VendorsController extends StateNotifier<VendorsState> {
   }
 
   Future<Vendor?> create(Map<String, dynamic> dto) async {
+    final repo = _ref.read(vendorsRepositoryProvider);
     try {
-      final repo = _ref.read(vendorsRepositoryProvider);
       final v = await repo.create(dto);
       state = state.copyWith(vendors: [...state.vendors, v]);
       return v;
     } on DioException catch (e) {
       state = state.copyWith(error: e.message);
+      if (e.response?.statusCode == 422) {
+        throw repo.map422(e);
+      }
       rethrow;
     }
   }
 
   Future<Vendor?> update(int id, Map<String, dynamic> dto) async {
+    final repo = _ref.read(vendorsRepositoryProvider);
     try {
-      final repo = _ref.read(vendorsRepositoryProvider);
       final v = await repo.update(id, dto);
       final idx = state.vendors.indexWhere((e) => e.id == id);
       if (idx != -1) {
@@ -53,6 +56,9 @@ class VendorsController extends StateNotifier<VendorsState> {
       return v;
     } on DioException catch (e) {
       state = state.copyWith(error: e.message);
+      if (e.response?.statusCode == 422) {
+        throw repo.map422(e);
+      }
       rethrow;
     }
   }

--- a/lib/features/proc/vendors/ui/vendor_detail.dart
+++ b/lib/features/proc/vendors/ui/vendor_detail.dart
@@ -12,7 +12,12 @@ class VendorDetail extends StatelessWidget {
   Widget build(BuildContext context) {
     final spacing = Theme.of(context).extension<AppSpacing>()!;
     return AlertDialog(
-      title: Text(vendor.razonSocial),
+      title: Row(
+        children: [
+          Expanded(child: Text(vendor.razonSocial)),
+          Chip(label: Text(vendor.activo ? 'Activo' : 'Inactivo')),
+        ],
+      ),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -30,6 +35,14 @@ class VendorDetail extends StatelessWidget {
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: const Text('Cerrar'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, 'delete'),
+          child: const Text('Eliminar'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, 'edit'),
+          child: const Text('Editar'),
         ),
       ],
     );

--- a/lib/features/proc/vendors/ui/vendor_form.dart
+++ b/lib/features/proc/vendors/ui/vendor_form.dart
@@ -59,6 +59,13 @@ class _VendorFormState extends State<VendorForm> {
               TextFormField(
                 controller: _email,
                 decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) {
+                  if (v == null || v.isEmpty) return null;
+                  final emailReg =
+                      RegExp(r'^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$');
+                  if (!emailReg.hasMatch(v)) return 'Email inválido';
+                  return null;
+                },
               ),
               SizedBox(height: spacing.sm),
               TextFormField(

--- a/lib/features/proc/vendors/ui/vendors_page.dart
+++ b/lib/features/proc/vendors/ui/vendors_page.dart
@@ -20,13 +20,17 @@ class VendorsPage extends HookConsumerWidget {
     final state = ref.watch(vendorsControllerProvider);
     final search = useTextEditingController();
     final timer = useRef<Timer?>(null);
+    final filter = useState<bool?>(null);
 
     useEffect(() {
       controller.load();
       void listener() {
         timer.value?.cancel();
         timer.value = Timer(const Duration(milliseconds: 400), () {
-          controller.load(params: {'search': search.text});
+          controller.load(params: {
+            'search': search.text,
+            if (filter.value != null) 'activo': filter.value! ? 1 : 0,
+          });
         });
       }
 
@@ -35,7 +39,7 @@ class VendorsPage extends HookConsumerWidget {
         timer.value?.cancel();
         search.removeListener(listener);
       };
-    }, []);
+    }, [filter.value]);
 
     Future<void> openForm([Vendor? vendor]) async {
       final data = await showDialog<Map<String, dynamic>>(
@@ -43,48 +47,167 @@ class VendorsPage extends HookConsumerWidget {
         builder: (_) => VendorForm(initial: vendor),
       );
       if (data != null) {
-        if (vendor == null) {
-          await controller.create(data);
-        } else {
-          await controller.update(vendor.id, data);
+        try {
+          if (vendor == null) {
+            await controller.create(data);
+          } else {
+            await controller.update(vendor.id, data);
+          }
+        } on Map<String, List<String>> catch (errors) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(errors.values.first.first)),
+          );
         }
       }
     }
 
+    Future<void> showDetail(Vendor v) async {
+      final action = await showDialog<String>(
+        context: context,
+        builder: (_) => VendorDetail(vendor: v),
+      );
+      if (action == 'edit') {
+        await openForm(v);
+      } else if (action == 'delete') {
+        final confirm = await showDialog<bool>(
+              context: context,
+              builder: (ctx) => AlertDialog(
+                title: const Text('Confirmar'),
+                content: const Text('¿Eliminar proveedor?'),
+                actions: [
+                  TextButton(
+                      onPressed: () => Navigator.pop(ctx, false),
+                      child: const Text('No')),
+                  FilledButton(
+                      onPressed: () => Navigator.pop(ctx, true),
+                      child: const Text('Sí')),
+                ],
+              ),
+            ) ??
+            false;
+        if (confirm) {
+          await controller.remove(v.id);
+        }
+      }
+    }
+
+    Widget buildList() {
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          final items = state.vendors;
+          if (constraints.maxWidth < 600) {
+            return ListView.builder(
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                final v = items[index];
+                return ListTile(
+                  title: Text(v.razonSocial),
+                  subtitle: Text(v.email ?? v.telefono ?? ''),
+                  trailing: Text(v.activo ? 'Activo' : 'Inactivo'),
+                  onTap: () => showDetail(v),
+                );
+              },
+            );
+          }
+          return DataTable(
+            columns: const [
+              DataColumn(label: Text('Razón social')),
+              DataColumn(label: Text('RUC')),
+              DataColumn(label: Text('Email/Teléfono')),
+              DataColumn(label: Text('Estado')),
+              DataColumn(label: Text('Acciones')),
+            ],
+            rows: [
+              for (final v in items)
+                DataRow(cells: [
+                  DataCell(Text(v.razonSocial)),
+                  DataCell(Text(v.ruc ?? '')),
+                  DataCell(Text(v.email ?? v.telefono ?? '')),
+                  DataCell(Text(v.activo ? 'Activo' : 'Inactivo')),
+                  DataCell(Row(
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.visibility),
+                        onPressed: () => showDetail(v),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.edit),
+                        onPressed: () => openForm(v),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: () async {
+                          final confirm = await showDialog<bool>(
+                                context: context,
+                                builder: (ctx) => AlertDialog(
+                                  title: const Text('Confirmar'),
+                                  content: const Text(
+                                      '¿Eliminar proveedor?'),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Navigator.pop(ctx, false),
+                                      child: const Text('No'),
+                                    ),
+                                    FilledButton(
+                                      onPressed: () => Navigator.pop(ctx, true),
+                                      child: const Text('Sí'),
+                                    ),
+                                  ],
+                                ),
+                              ) ??
+                              false;
+                          if (confirm) {
+                            await controller.remove(v.id);
+                          }
+                        },
+                      ),
+                    ],
+                  )),
+                ])
+            ],
+          );
+        },
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('Proveedores')),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => openForm(),
-        child: const Icon(Icons.add),
-      ),
       body: Column(
         children: [
           Padding(
             padding: EdgeInsets.all(spacing.sm),
-            child: TextField(
-              controller: search,
-              decoration: const InputDecoration(hintText: 'Buscar'),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: search,
+                    decoration: const InputDecoration(hintText: 'Buscar'),
+                  ),
+                ),
+                SizedBox(width: spacing.sm),
+                DropdownButton<bool?>(
+                  value: filter.value,
+                  hint: const Text('Estado'),
+                  onChanged: (v) => filter.value = v,
+                  items: const [
+                    DropdownMenuItem(value: null, child: Text('Todos')),
+                    DropdownMenuItem(value: true, child: Text('Activos')),
+                    DropdownMenuItem(value: false, child: Text('Inactivos')),
+                  ],
+                ),
+                SizedBox(width: spacing.sm),
+                FilledButton.icon(
+                  onPressed: () => openForm(),
+                  icon: const Icon(Icons.add),
+                  label: const Text('Nuevo'),
+                ),
+              ],
             ),
           ),
           Expanded(
             child: state.isLoading
                 ? const Center(child: CircularProgressIndicator())
-                : ListView.builder(
-                    itemCount: state.vendors.length,
-                    itemBuilder: (context, index) {
-                      final v = state.vendors[index];
-                      return ListTile(
-                        title: Text(v.razonSocial),
-                        subtitle: Text(v.email ?? v.telefono ?? ''),
-                        trailing: Text(v.activo ? 'Activo' : 'Inactivo'),
-                        onTap: () => showDialog(
-                          context: context,
-                          builder: (_) => VendorDetail(vendor: v),
-                        ),
-                        onLongPress: () => openForm(v),
-                      );
-                    },
-                  ),
+                : buildList(),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- add full CRUD for customers and vendors with search, filters and responsive tables
- handle 422 validation mapping and detail dialogs with actions
- document clients and vendors module

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dcfd24b0832f93e14aaf428bfb8e