### PR TITLE
docs: add reports module docs and APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,66 @@ Estados: `borrador`, `enviada`, `aceptada`, `rechazada`, `expirada`.
 
 La lista y formularios usan los mismos widgets adaptándose entre móvil y web.
 
+## Frontend / Reportes
+
+Conjunto de reportes clave con filtros unificados y exportación de datos.
+
+### Estructura y navegación
+
+- Ruta base `/reportes` con pestañas **Ventas**, **Caja**, **Inventario** y **CxP/CxC**.
+- En cada pestaña se preservan filtros y página actual.
+- Todas las fechas usan zona horaria `America/Guayaquil`.
+
+### Filtros
+
+- Encabezado común con **desde/hasta** y selector de **local**.
+- Botones: **Aplicar**, **Exportar** (CSV/XLS) y **Limpiar**.
+- Filtros adicionales por reporte, por ejemplo vendedor o método de pago.
+- Validación de rango y obligatoriedad de `local_id`.
+
+### Exportación
+
+- Preferentemente el backend soporta `?export=csv|xlsx`.
+- Si no existe, se genera el archivo en el cliente recorriendo todas las páginas.
+- Archivos nombrados `<reporte>-<YYYYMMDD>-<local>.csv|xlsx`.
+
+### Paginación
+
+- Soporte de `page/per_page` o `next_cursor`.
+- En móvil usa *infinite scroll*; en web, tabla con **Cargar más**.
+
+### Subpantallas
+
+1. **Ventas** – tarjetas con totales y tabla de facturas. Filtros por vendedor, método de pago y estado SRI. Incluye sección *Top productos*.
+2. **Caja** – resumen por método y movimientos de apertura/cierre. Filtros por operador, método y estado.
+3. **Inventario bajo** – lista de productos por debajo del mínimo con opción de generar compras. Filtros por bodega, categoría y “solo bajo mínimo”.
+4. **CxP/CxC** – pestañas internas con saldos, vencidos y tabla de documentos. Filtros por entidad, estado y rango de vencimiento.
+
+### Estados de carga
+
+- Esqueletos mientras se consultan datos, mensajes para vacíos y banners de error con reintento.
+
+### Responsive y theming
+
+- Un único código para móvil y web con layouts adaptativos.
+- Colores, espaciados y radios provienen de `ThemeExtension` (`AppColors`, `AppSpacing`, `AppRadius`).
+- Paletas editables en `assets/theme/theme.json`.
+
+### Endpoints usados
+
+| Método | Ruta | Descripción | Parámetros |
+| ------ | ---- | ----------- | ---------- |
+| GET | `/v1/reportes/ventas-dia` | Reporte de ventas por día | `desde`, `hasta`, `local_id`, `page`, `per_page` |
+| GET | `/v1/reportes/productos-mas-vendidos` | Top productos | `desde`, `hasta`, `local_id`, `top`, `page`, `per_page` |
+| GET | `/v1/reportes/caja` | Reporte de caja | `desde`, `hasta`, `local_id`, `page`, `per_page` |
+| GET | `/v1/reportes/inventario-bajo` | Inventario bajo mínimos | `local_id`, `bodega_id`, `page`, `per_page` |
+| GET | `/v1/reportes/cxp` | Reporte CxP | `proveedor_id`, `desde`, `hasta`, `estado`, `page`, `per_page` |
+| GET | `/v1/reportes/cxc` | Reporte CxC | `cliente_id`, `desde`, `hasta`, `estado`, `page`, `per_page` |
+
+### Notas de compatibilidad
+
+- Si algún endpoint aún no existe, se usan endpoints de ventas, caja, stock o cuentas con agregación en el cliente.
+
 ## Guard Global
 
 El router redirige las rutas protegidas según el estado:

--- a/api_registry.json
+++ b/api_registry.json
@@ -23,7 +23,7 @@
   {
     "method": "GET",
     "path": "/v1/reportes/ventas-dia",
-    "name": "Ventas por hora",
+    "name": "Reporte de ventas por día",
     "module": "reportes",
     "permission": "reportes.ventas.ver"
   },
@@ -32,7 +32,35 @@
     "path": "/v1/reportes/productos-mas-vendidos",
     "name": "Top productos",
     "module": "reportes",
-    "permission": "reportes.productos.ver"
+    "permission": "reportes.ventas.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/caja",
+    "name": "Reporte de caja",
+    "module": "reportes",
+    "permission": "reportes.caja.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/inventario-bajo",
+    "name": "Inventario bajo mínimos",
+    "module": "reportes",
+    "permission": "reportes.inventario.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/cxp",
+    "name": "Reporte CxP",
+    "module": "reportes",
+    "permission": "reportes.cxp.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/cxc",
+    "name": "Reporte CxC",
+    "module": "reportes",
+    "permission": "reportes.cxc.ver"
   },
   {
     "method": "GET",


### PR DESCRIPTION
## Summary
- document the Reports section with navigation, filters, export and pagination
- register report endpoints in `api_registry.json`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e029fa28832fa3e28d051af5a63f