### PR TITLE
fix: ensure totals footer is widget

### DIFF
--- a/lib/features/cash/close/ui/close_cash_page.dart
+++ b/lib/features/cash/close/ui/close_cash_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../controllers/close_cash_controller.dart';
-import '../../common/cash_repository.dart';
 import 'method_count_row.dart';
 import 'totals_footer.dart';
 
@@ -32,7 +31,7 @@ class CloseCashPage extends ConsumerWidget {
           ),
           Padding(
             padding: const EdgeInsets.all(16),
-            child: TotalsFooter(),
+            child: const TotalsFooter(),
           )
         ],
       ),

--- a/lib/features/cash/close/ui/totals_footer.dart
+++ b/lib/features/cash/close/ui/totals_footer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../controllers/close_cash_controller.dart';
 


### PR DESCRIPTION
## Summary
- remove unused CashRepository import
- mark TotalsFooter as const and import hooks_riverpod

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4862622e4832f910156803909ed12