### PR TITLE
fix: ensure product autocomplete returns iterable

### DIFF
--- a/lib/features/inventory/common/product_autocomplete_field.dart
+++ b/lib/features/inventory/common/product_autocomplete_field.dart
@@ -36,7 +36,8 @@ class ProductAutocompleteField extends HookConsumerWidget {
         if (query.length < 2) return const Iterable<Product>.empty();
         debounce.value?.cancel();
         debounce.value = Timer(const Duration(milliseconds: 300), () {});
-        final result = ref.watch(productsSearchProvider(query)).value ?? [];
+        final result =
+            ref.watch(productsSearchProvider(query)).value ?? <Product>[];
         return result;
       },
       onSelected: (p) {


### PR DESCRIPTION
## Summary
- ensure typed list is returned in product autocomplete options builder

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a489690aa0832f955cb94bf94c125c