### PR TITLE
Add shared preferences dependency and tidy context imports

### DIFF
--- a/lib/features/context/controllers/context_controller.dart
+++ b/lib/features/context/controllers/context_controller.dart
@@ -5,7 +5,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../../core/routing/app_router.dart';
 import '../data/context_repository.dart';
 import '../data/local.dart';
-import '../data/subscription_status.dart';
 
 class ContextState {
   const ContextState({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   flutter_dotenv: ^5.0.2
   intl: ^0.18.0
   uuid: ^4.1.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- remove unused subscription status import
- add shared_preferences dependency to project

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48959b50c832faad6baab1537144f