### PR TITLE
Fix Autocomplete options builder typing in stock page

### DIFF
--- a/lib/features/inventory/stock/ui/stock_page.dart
+++ b/lib/features/inventory/stock/ui/stock_page.dart
@@ -73,7 +73,7 @@ class StockPage extends HookConsumerWidget {
                     debounce.value =
                         Timer(const Duration(milliseconds: 300), () {});
                     final result =
-                        ref.watch(productsSearchProvider(query)).value ?? [];
+                        ref.watch(productsSearchProvider(query)).value ?? <Product>[];
                     return result;
                   },
                   onSelected: (p) {


### PR DESCRIPTION
## Summary
- ensure product search Autocomplete returns a typed `List<Product>`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a489d0c3a8832fa999629df9f24eed