### PR TITLE
Fix Dio request method parameter usage in invoice repository

### DIFF
--- a/lib/features/invoices/data/invoices_repository.dart
+++ b/lib/features/invoices/data/invoices_repository.dart
@@ -25,13 +25,21 @@ class InvoicesRepository {
     Options? options,
     data,
   }) async {
+    final requestOptions = options ?? Options();
+    requestOptions.method = method;
     try {
-      return await _dio.request(primary,
-          data: data, options: options, method: method);
+      return await _dio.request(
+        primary,
+        data: data,
+        options: requestOptions,
+      );
     } on DioException catch (e) {
       if (e.response?.statusCode == 404) {
-        return await _dio.request(fallback,
-            data: data, options: options, method: method);
+        return await _dio.request(
+          fallback,
+          data: data,
+          options: requestOptions,
+        );
       }
       rethrow;
     }


### PR DESCRIPTION
## Summary
- set request method through Options instead of undefined parameter

## Testing
- `dart format lib/features/invoices/data/invoices_repository.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a489de647c832f98afb0ff9fbc0fd2