### PR TITLE
fix test adapter in context_controller_test

### DIFF
--- a/test/context_controller_test.dart
+++ b/test/context_controller_test.dart
@@ -16,7 +16,7 @@ class FakeContextRepository extends Mock implements ContextRepository {}
 
 class FakeGoRouter extends Mock implements GoRouter {}
 
-class TestAdapter extends HttpClientAdapter {
+class TestAdapter implements HttpClientAdapter {
   RequestOptions? options;
   @override
   void close({bool force = false}) {}
@@ -25,7 +25,7 @@ class TestAdapter extends HttpClientAdapter {
   Future<ResponseBody> fetch(RequestOptions options, Stream<List<int>>? requestStream,
       Future? cancelFuture) async {
     this.options = options;
-    return ResponseBody.fromString('', 200, headers: {}, statusCode: 200);
+    return ResponseBody.fromString('', 200, headers: {});
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure TestAdapter implements HttpClientAdapter to avoid generative constructor error
- remove invalid statusCode named parameter from ResponseBody.fromString

## Testing
- `flutter test test/context_controller_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48bd3db14832f9f5a43b926654962