### PR TITLE
Fix context controller override in dashboard controller test

### DIFF
--- a/test/dashboard_controller_test.dart
+++ b/test/dashboard_controller_test.dart
@@ -45,8 +45,10 @@ class FakeDashboardRepository implements DashboardRepository {
   }
 }
 
-class FakeContextController extends StateNotifier<ContextState> {
-  FakeContextController() : super(const ContextState(localId: 1));
+class FakeContextController extends ContextController {
+  FakeContextController(Ref ref) : super(ref) {
+    state = const ContextState(localId: 1);
+  }
 }
 
 void main() {
@@ -54,7 +56,7 @@ void main() {
     final container = ProviderContainer(overrides: [
       dashboardRepositoryProvider.overrideWithValue(FakeDashboardRepository()),
       contextControllerProvider.overrideWith(
-        (ref) => FakeContextController(),
+        (ref) => FakeContextController(ref),
       ),
     ]);
     final controller = container.read(dashboardControllerProvider.notifier);


### PR DESCRIPTION
## Summary
- Fix dashboard controller test by overriding context controller with a proper ContextController

## Testing
- `flutter test test/dashboard_controller_test.dart` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a48bf0007c832f9fe9a5b9d4c0c8ba