### PR TITLE
fix: update invoices repository tests for dio 5

### DIFF
--- a/test/invoices_repository_test.dart
+++ b/test/invoices_repository_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'package:punto_venta_front/features/invoices/data/invoices_repository.dart';
-import 'package:punto_venta_front/features/invoices/data/models/invoice.dart';
 
 class MockDio extends Mock implements Dio {}
 
@@ -15,14 +14,14 @@ void main() {
   test('getInvoice falls back to legacy path on 404', () async {
     final dio = MockDio();
     when(() => dio.request('/v1/facturas/1',
-            method: 'GET', data: null, options: any(named: 'options')))
+            data: null, options: any(named: 'options')))
         .thenThrow(DioException(
             requestOptions: RequestOptions(path: '/v1/facturas/1'),
             response: Response(
                 requestOptions: RequestOptions(path: '/v1/facturas/1'),
                 statusCode: 404)));
     when(() => dio.request('/v1/ventas/facturas/1',
-            method: 'GET', data: null, options: any(named: 'options')))
+            data: null, options: any(named: 'options')))
         .thenAnswer((_) async => Response(
               requestOptions: RequestOptions(path: '/v1/ventas/facturas/1'),
               statusCode: 200,
@@ -41,16 +40,22 @@ void main() {
     final repo = InvoicesRepository(dio);
     final invoice = await repo.getInvoice(1);
     expect(invoice.id, 1);
-    verify(() => dio.request('/v1/facturas/1',
-        method: 'GET', data: null, options: any(named: 'options'))).called(1);
-    verify(() => dio.request('/v1/ventas/facturas/1',
-        method: 'GET', data: null, options: any(named: 'options'))).called(1);
+    final primaryVerification = verify(() => dio.request('/v1/facturas/1',
+        data: null, options: captureAny(named: 'options')));
+    primaryVerification.called(1);
+    final primaryOptions = primaryVerification.captured.first as Options;
+    expect(primaryOptions.method, 'GET');
+    final fallbackVerification = verify(() => dio.request('/v1/ventas/facturas/1',
+        data: null, options: captureAny(named: 'options')));
+    fallbackVerification.called(1);
+    final fallbackOptions = fallbackVerification.captured.first as Options;
+    expect(fallbackOptions.method, 'GET');
   });
 
   test('emit adds Idempotency-Key header', () async {
     final dio = MockDio();
     when(() => dio.request('/v1/facturas/1/emitir',
-            method: 'POST', data: null, options: any(named: 'options')))
+            data: null, options: any(named: 'options')))
         .thenAnswer((invocation) async {
       return Response(
         requestOptions: RequestOptions(path: '/v1/facturas/1/emitir'),
@@ -61,19 +66,19 @@ void main() {
     final repo = InvoicesRepository(dio);
     final status = await repo.emit(1);
     expect(status, 'enviada');
-    final captured = verify(() => dio.request('/v1/facturas/1/emitir',
-            method: 'POST', data: null, options: captureAny(named: 'options')))
-        .captured
-        .first as Options;
+    final verification = verify(() => dio.request('/v1/facturas/1/emitir',
+            data: null, options: captureAny(named: 'options')));
+    verification.called(1);
+    final captured = verification.captured.first as Options;
     final key = captured.headers?['Idempotency-Key'] as String?;
     expect(key, isNotNull);
     expect(key, startsWith('EMIT-1-'));
+    expect(captured.method, 'POST');
   });
 
   test('cancel adds Idempotency-Key header', () async {
     final dio = MockDio();
     when(() => dio.request('/v1/facturas/1/anular',
-            method: 'POST',
             data: any(named: 'data'),
             options: any(named: 'options')))
         .thenAnswer((_) async => Response(
@@ -87,14 +92,14 @@ void main() {
             ));
     final repo = InvoicesRepository(dio);
     await repo.cancel(1, 'motivo valido 123');
-    final captured = verify(() => dio.request('/v1/facturas/1/anular',
-            method: 'POST',
+    final verification = verify(() => dio.request('/v1/facturas/1/anular',
             data: any(named: 'data'),
-            options: captureAny(named: 'options')))
-        .captured
-        .first as Options;
+            options: captureAny(named: 'options')));
+    verification.called(1);
+    final captured = verification.captured.first as Options;
     final key = captured.headers?['Idempotency-Key'] as String?;
     expect(key, isNotNull);
     expect(key, startsWith('NC-1-'));
+    expect(captured.method, 'POST');
   });
 }


### PR DESCRIPTION
## Summary
- update test mocks to capture request options instead of using removed `method` parameter
- assert idempotency headers and HTTP methods via `Options`

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a48c1938a8832f9e5a0e6d2729af45