### PR TITLE
Fix context controller override in dashboard page test

### DIFF
--- a/test/dashboard_page_test.dart
+++ b/test/dashboard_page_test.dart
@@ -33,8 +33,21 @@ class FakeDashboardRepository implements DashboardRepository {
       const SubscriptionInfo(estado: 'active');
 }
 
-class FakeContextController extends StateNotifier<ContextState> {
-  FakeContextController() : super(const ContextState(localId: 1));
+class FakeContextController extends ContextController {
+  FakeContextController(Ref ref) : super(ref) {
+    state = const ContextState(localId: 1);
+  }
+
+  @override
+  Future<void> loadContext() async {}
+
+  @override
+  Future<void> selectLocal(int localId) async {}
+
+  @override
+  void setHeaderXLocalId(int? localId) {
+    state = state.copyWith(localId: localId);
+  }
 }
 
 void main() {
@@ -42,7 +55,7 @@ void main() {
     await tester.pumpWidget(ProviderScope(
       overrides: [
         dashboardRepositoryProvider.overrideWithValue(FakeDashboardRepository()),
-        contextControllerProvider.overrideWith((ref) => FakeContextController()),
+        contextControllerProvider.overrideWith((ref) => FakeContextController(ref)),
       ],
       child: const MaterialApp(home: DashboardPage()),
     ));


### PR DESCRIPTION
## Summary
- Ensure `contextControllerProvider` is overridden with a `ContextController` instance in `dashboard_page_test`
- Stubbed fake controller methods and preset state for tests

## Testing
- `flutter test test/dashboard_page_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48c010b4c832fada4d32e6b2c0e50