### PR TITLE
Oculta etiqueta de depuración

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ class MyApp extends ConsumerWidget {
       title: 'Punto Venta',
       theme: theme,
       routerConfig: router,
+      debugShowCheckedModeBanner: false,
       locale: const Locale('es', 'EC'),
       supportedLocales: const [Locale('es', 'EC')],
       localizationsDelegates: const [


### PR DESCRIPTION
## Summary
- Oculta la leyenda de DEBUG en la app al desactivar `debugShowCheckedModeBanner`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4992d1ccc832f96e28503d75386a5