### PR TITLE
Fix router login redirection

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -76,7 +76,10 @@ final routerProvider = Provider<GoRouter>((ref) {
     redirect: (context, state) {
       final auth = ref.read(authStateProvider);
       final subRepo = ref.read(subscriptionRepositoryProvider);
-      final location = state.matchedLocation;
+      // Using the state's URI path prevents issues when query parameters or
+      // trailing slashes are present, ensuring redirection works consistently
+      // after a successful login.
+      final location = state.uri.path;
       if (location == '/subscription/blocked') {
         return null;
       }


### PR DESCRIPTION
## Summary
- use state.uri.path for redirect comparisons to ensure navigation after login

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aa0ff528832fa78787c2a605e317