### PR TITLE
Store login local ID and include it in subscription checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pantalla responsive (móvil y web) que permite iniciar sesión con email y contr
 1. El usuario ingresa sus credenciales y envía el formulario.
 2. `POST /v1/auth/login` devuelve `token`, expiración (`exp` o `expires_in`), `user` y `locales`.
 3. Se guarda el JWT en `flutter_secure_storage` junto con su TTL.
-4. Se verifica la suscripción con `GET /v1/estado-suscripcion`.
+4. Se verifica la suscripción con `GET /v1/estado-suscripcion?local_id=<id>`.
 5. Navegación:
    - Múltiples locales → `/selector-local`.
    - Único local → `/dashboard`.
@@ -38,7 +38,7 @@ flutter test
 | Método | Ruta | Descripción |
 | ------ | ---- | ----------- |
 | POST | `/v1/auth/login` | Inicio de sesión |
-| GET | `/v1/estado-suscripcion` | Verificación de suscripción |
+| GET | `/v1/estado-suscripcion?local_id=…` | Verificación de suscripción |
 | GET | `/v1/tenancy/context` | Contexto de locales (opcional) |
 
 ## Frontend / Selector de Empresa/Local
@@ -92,7 +92,7 @@ Todas las fechas se calculan con zona horaria `America/Guayaquil` para cortes di
 | ------ | ---- | ----------- |
 | GET | `/v1/reportes/ventas-dia` | Ventas del día por hora |
 | GET | `/v1/reportes/productos-mas-vendidos` | Top de productos del día |
-| GET | `/v1/estado-suscripcion` | Estado de suscripción para alertas |
+| GET | `/v1/estado-suscripcion?local_id=…` | Estado de suscripción para alertas |
 | GET | `/v1/caja/estado` | Estado de la caja del local actual |
 
 La interfaz es responsive y utiliza los mismos componentes en móvil y web.
@@ -859,7 +859,7 @@ Las respuestas `401` provocan un `refresh()` automático; `403` consulta el esta
 | POST | `/v1/auth/login` | Inicio de sesión |
 | POST | `/v1/auth/refresh` | Renovación de token |
 | GET | `/v1/auth/me` | Perfil actual |
-| GET | `/v1/estado-suscripcion` | Verificación de suscripción |
+| GET | `/v1/estado-suscripcion?local_id=…` | Verificación de suscripción |
 
 ## Cómo correr
 

--- a/lib/data/subscription/subscription_repository.dart
+++ b/lib/data/subscription/subscription_repository.dart
@@ -2,6 +2,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:dio/dio.dart';
 
 import '../../core/network/dio_client.dart';
+import '../auth/auth_repository.dart';
 
 final subscriptionRepositoryProvider = Provider<SubscriptionRepository>((ref) {
   return SubscriptionRepository(ref); 
@@ -17,8 +18,11 @@ class SubscriptionRepository {
 
   Future<void> refresh() async {
     final dio = _ref.read(dioProvider);
+    final authRepo = _ref.read(authRepositoryProvider);
     try {
-      final resp = await dio.get('/v1/estado-suscripcion');
+      final localId = await authRepo.getLocalId();
+      final resp = await dio.get('/v1/estado-suscripcion',
+          queryParameters: localId != null ? {'local_id': localId} : null);
       if (resp.statusCode == 200) {
         _active = resp.data['estado'] == 'active';
       } else if (resp.statusCode == 403) {

--- a/lib/features/dashboard/controllers/dashboard_controller.dart
+++ b/lib/features/dashboard/controllers/dashboard_controller.dart
@@ -81,7 +81,7 @@ class DashboardController extends StateNotifier<DashboardState> {
       final productos =
           await repo.fetchTopProductos(desde: desde, hasta: hasta, localId: localId);
       final cajaAbierta = await repo.isCajaAbierta(localId);
-      final sub = await repo.fetchEstadoSuscripcion();
+      final sub = await repo.fetchEstadoSuscripcion(localId: localId);
 
       final ventasTotales = ventas
           .fold<double>(0, (sum, e) => sum + e.ventasTotales);

--- a/lib/features/dashboard/data/dashboard_repository.dart
+++ b/lib/features/dashboard/data/dashboard_repository.dart
@@ -72,14 +72,15 @@ class DashboardRepository {
     }
   }
 
-  Future<SubscriptionInfo> fetchEstadoSuscripcion() async {
+  Future<SubscriptionInfo> fetchEstadoSuscripcion({required int localId}) async {
     final now = DateTime.now();
     if (_cachedSub != null &&
         _cachedAt != null &&
         now.difference(_cachedAt!).inMinutes < 5) {
       return _cachedSub!;
     }
-    final resp = await _dio.get('/v1/estado-suscripcion');
+    final resp = await _dio.get('/v1/estado-suscripcion',
+        queryParameters: {'local_id': localId});
     final sub = SubscriptionInfo.fromJson(resp.data as Map<String, dynamic>);
     _cachedSub = sub;
     _cachedAt = now;

--- a/test/auth_repository_test.dart
+++ b/test/auth_repository_test.dart
@@ -36,6 +36,7 @@ void main() {
         data: {
           'token': 'abc',
           'expires_in': 86400,
+          'local_id': 1,
           'user': {'id': 1, 'nombre': 'Demo', 'email': 'd@e.com'},
         },
       ),
@@ -44,6 +45,7 @@ void main() {
     await repo.login('demo', 'pw');
 
     expect(await storage.read(key: 'token'), 'abc');
+    expect(await storage.read(key: 'local_id'), '1');
     final exp = await repo.getExpiresAt();
     expect(exp!.difference(DateTime.now()).inHours, closeTo(24, 1));
   });
@@ -60,6 +62,7 @@ void main() {
         data: {
           'token': 'abc',
           'exp': DateTime.now().add(const Duration(hours: 10)).millisecondsSinceEpoch ~/ 1000,
+          'local_id': 2,
           'user': {'id': 1, 'nombre': 'Demo', 'email': 'd@e.com'},
         },
       ),
@@ -83,6 +86,7 @@ void main() {
         data: {
           'token': 'abc',
           'expires_in': 86400,
+          'local_id': 3,
           // no user field
         },
       ),

--- a/test/dashboard_controller_test.dart
+++ b/test/dashboard_controller_test.dart
@@ -35,7 +35,7 @@ class FakeDashboardRepository implements DashboardRepository {
   Future<bool> isCajaAbierta(int localId) async => false;
 
   @override
-  Future<SubscriptionInfo> fetchEstadoSuscripcion() async {
+  Future<SubscriptionInfo> fetchEstadoSuscripcion({required int localId}) async {
     final futureDate = DateTime.now().add(const Duration(days: 5));
     return SubscriptionInfo(
       estado: 'active',

--- a/test/dashboard_page_test.dart
+++ b/test/dashboard_page_test.dart
@@ -29,7 +29,7 @@ class FakeDashboardRepository implements DashboardRepository {
   Future<bool> isCajaAbierta(int localId) async => true;
 
   @override
-  Future<SubscriptionInfo> fetchEstadoSuscripcion() async =>
+  Future<SubscriptionInfo> fetchEstadoSuscripcion({required int localId}) async =>
       const SubscriptionInfo(estado: 'active');
 }
 


### PR DESCRIPTION
## Summary
- Save `local_id` from login alongside the auth token
- Query subscription status using saved `local_id`
- Pass `local_id` to dashboard subscription calls and update docs/tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b3559d90832fb9225ffc83ce12be