### PR TITLE
feat(dashboard): add new sale shortcut

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -14,6 +14,7 @@ import '../../features/products/ui/products_page.dart';
 import '../../features/invoices/ui/invoice_detail_page.dart';
 import '../../features/inventory/ui/inventory_page.dart';
 import '../../features/inventory/movements/ui/movements_page.dart';
+import '../../features/quotes/ui/quote_form_page.dart';
 
 class GoRouterRefreshStream extends ChangeNotifier {
   GoRouterRefreshStream(Stream<dynamic> stream) {
@@ -64,6 +65,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/productos',
         builder: (context, state) => const ProductsPage(),
+      ),
+      GoRoute(
+        path: '/ventas/nueva',
+        builder: (context, state) => const QuoteFormPage(),
       ),
       GoRoute(
         path: '/facturas/:id',

--- a/lib/features/dashboard/ui/dashboard_page.dart
+++ b/lib/features/dashboard/ui/dashboard_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../core/theme/app_spacing.dart';
 import '../controllers/dashboard_controller.dart';
@@ -110,6 +111,11 @@ class DashboardPage extends HookConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
       body: content,
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.push('/ventas/nueva'),
+        icon: const Icon(Icons.point_of_sale),
+        label: const Text('Nueva venta'),
+      ),
     );
   }
 }

--- a/test/dashboard_page_test.dart
+++ b/test/dashboard_page_test.dart
@@ -62,4 +62,16 @@ void main() {
     await tester.pump();
     expect(find.text('Dashboard'), findsOneWidget);
   });
+
+  testWidgets('DashboardPage has new sale button', (tester) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        dashboardRepositoryProvider.overrideWithValue(FakeDashboardRepository()),
+        contextControllerProvider.overrideWith((ref) => FakeContextController(ref)),
+      ],
+      child: const MaterialApp(home: DashboardPage()),
+    ));
+    await tester.pump();
+    expect(find.text('Nueva venta'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- add "Nueva venta" button in dashboard to open sales flow
- route `/ventas/nueva` to QuoteFormPage
- test dashboard shows new sale button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b4dd4af4832fb0326ab45b663df3