### PR TITLE
Add navigation drawer menu

### DIFF
--- a/lib/core/ui/menu_drawer.dart
+++ b/lib/core/ui/menu_drawer.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Drawer used across the app to navigate between available screens.
+class MenuDrawer extends StatelessWidget {
+  const MenuDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        children: [
+          const DrawerHeader(child: Text('Menú')),
+          ListTile(
+            leading: const Icon(Icons.dashboard),
+            title: const Text('Dashboard'),
+            onTap: () => context.go('/dashboard'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.inventory),
+            title: const Text('Inventario'),
+            onTap: () => context.go('/inventario'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.swap_horiz),
+            title: const Text('Movimientos'),
+            onTap: () => context.go('/inventario/movimientos'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.shopping_cart),
+            title: const Text('Productos'),
+            onTap: () => context.go('/productos'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/ui/dashboard_page.dart
+++ b/lib/features/dashboard/ui/dashboard_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../core/theme/app_spacing.dart';
+import '../../../core/ui/menu_drawer.dart';
 import '../controllers/dashboard_controller.dart';
 import 'widgets/kpi_card.dart';
 import 'widgets/alert_banner.dart';
@@ -109,6 +110,7 @@ class DashboardPage extends HookConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
+      drawer: const MenuDrawer(),
       body: content,
     );
   }

--- a/lib/features/inventory/movements/ui/movements_page.dart
+++ b/lib/features/inventory/movements/ui/movements_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../adjust/ui/adjust_page.dart';
 import '../../transfer/ui/transfer_page.dart';
+import '../../../../core/ui/menu_drawer.dart';
 
 class InventoryMovementsPage extends StatelessWidget {
   const InventoryMovementsPage({super.key});
@@ -20,6 +21,7 @@ class InventoryMovementsPage extends StatelessWidget {
             ],
           ),
         ),
+        drawer: const MenuDrawer(),
         body: const TabBarView(
           children: [
             AdjustPage(),

--- a/lib/features/inventory/ui/inventory_page.dart
+++ b/lib/features/inventory/ui/inventory_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../bodegas/ui/bodegas_page.dart';
 import '../stock/ui/stock_page.dart';
+import '../../../core/ui/menu_drawer.dart';
 
 class InventoryPage extends StatelessWidget {
   const InventoryPage({super.key});
@@ -20,6 +21,7 @@ class InventoryPage extends StatelessWidget {
             ],
           ),
         ),
+        drawer: const MenuDrawer(),
         body: const TabBarView(
           children: [
             BodegasPage(),

--- a/lib/features/products/ui/products_page.dart
+++ b/lib/features/products/ui/products_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../core/theme/app_spacing.dart';
+import '../../../core/ui/menu_drawer.dart';
 import '../controllers/products_controller.dart';
 import '../data/models/product.dart';
 import 'product_form.dart';
@@ -28,6 +29,7 @@ class ProductsPage extends HookConsumerWidget {
       appBar: AppBar(
         title: const Text('Productos'),
       ),
+      drawer: const MenuDrawer(),
       body: Padding(
         padding: EdgeInsets.all(spacing.md),
         child: Column(


### PR DESCRIPTION
## Summary
- add reusable drawer with links to Dashboard, Inventario, Movimientos and Productos
- integrate drawer into Dashboard, Inventory, Movements and Products pages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b5824610832fb55330dae6307f0d