### PR TITLE
Use vigente field to detect active subscription

### DIFF
--- a/lib/data/subscription/subscription_repository.dart
+++ b/lib/data/subscription/subscription_repository.dart
@@ -24,7 +24,18 @@ class SubscriptionRepository {
       final resp = await dio.get('/v1/estado-suscripcion',
           queryParameters: localId != null ? {'local_id': localId} : null);
       if (resp.statusCode == 200) {
-        _active = resp.data['estado'] == 'active';
+        final data = resp.data is Map<String, dynamic> &&
+                resp.data.containsKey('data')
+            ? resp.data['data'] as Map<String, dynamic>
+            : resp.data as Map<String, dynamic>;
+        final vigente = data['vigente'];
+        if (vigente is bool) {
+          _active = vigente;
+        } else if (vigente is num) {
+          _active = vigente != 0;
+        } else {
+          _active = false;
+        }
       } else if (resp.statusCode == 403) {
         _active = false;
       }

--- a/lib/features/context/data/context_repository.dart
+++ b/lib/features/context/data/context_repository.dart
@@ -37,11 +37,19 @@ class ContextRepository {
     try {
       final resp = await _dio.get('/v1/estado-suscripcion',
           queryParameters: localId != null ? {'local_id': localId} : null);
-      return SubscriptionStatus.fromJson(resp.data as Map<String, dynamic>);
+      final data = resp.data is Map<String, dynamic> &&
+              resp.data.containsKey('data')
+          ? resp.data['data'] as Map<String, dynamic>
+          : resp.data as Map<String, dynamic>;
+      return SubscriptionStatus.fromJson(data);
     } on DioException catch (e) {
       if (e.response?.statusCode == 400 || e.response?.statusCode == 404) {
         final resp = await _dio.get('/v1/estado-suscripcion');
-        return SubscriptionStatus.fromJson(resp.data as Map<String, dynamic>);
+        final data = resp.data is Map<String, dynamic> &&
+                resp.data.containsKey('data')
+            ? resp.data['data'] as Map<String, dynamic>
+            : resp.data as Map<String, dynamic>;
+        return SubscriptionStatus.fromJson(data);
       }
       rethrow;
     }

--- a/lib/features/context/data/subscription_status.dart
+++ b/lib/features/context/data/subscription_status.dart
@@ -7,10 +7,20 @@ class SubscriptionStatus {
 
   factory SubscriptionStatus.fromJson(Map<String, dynamic> json) {
     if (json.containsKey('vigente')) {
+      final vig = json['vigente'];
+      final bool vigente;
+      if (vig is bool) {
+        vigente = vig;
+      } else if (vig is num) {
+        vigente = vig != 0;
+      } else {
+        vigente = vig?.toString() == '1';
+      }
       return SubscriptionStatus(
-        vigente: json['vigente'] as bool,
+        vigente: vigente,
         estado: json['estado'] as String?,
-        fechaFin: json['fecha_fin'] as String? ?? json['next_renewal_at'] as String?,
+        fechaFin:
+            json['fecha_fin'] as String? ?? json['next_renewal_at'] as String?,
       );
     }
     final estado = json['estado'] as String?;

--- a/lib/features/dashboard/data/dashboard_repository.dart
+++ b/lib/features/dashboard/data/dashboard_repository.dart
@@ -81,7 +81,11 @@ class DashboardRepository {
     }
     final resp = await _dio.get('/v1/estado-suscripcion',
         queryParameters: {'local_id': localId});
-    final sub = SubscriptionInfo.fromJson(resp.data as Map<String, dynamic>);
+    final data = resp.data is Map<String, dynamic> &&
+            resp.data.containsKey('data')
+        ? resp.data['data'] as Map<String, dynamic>
+        : resp.data as Map<String, dynamic>;
+    final sub = SubscriptionInfo.fromJson(data);
     _cachedSub = sub;
     _cachedAt = now;
     return sub;

--- a/lib/features/dashboard/data/models/subscription_info.dart
+++ b/lib/features/dashboard/data/models/subscription_info.dart
@@ -9,9 +9,24 @@ class SubscriptionInfo {
   final String? trialEndsAt;
   final String? nextRenewalAt;
 
-  factory SubscriptionInfo.fromJson(Map<String, dynamic> json) => SubscriptionInfo(
-        estado: json['estado'] as String,
-        trialEndsAt: json['trial_ends_at'] as String?,
-        nextRenewalAt: json['next_renewal_at'] as String?,
-      );
+  factory SubscriptionInfo.fromJson(Map<String, dynamic> json) {
+    final vig = json['vigente'];
+    String? estado = json['estado'] as String?;
+    if (estado == null) {
+      bool vigente = false;
+      if (vig is bool) {
+        vigente = vig;
+      } else if (vig is num) {
+        vigente = vig != 0;
+      } else if (vig != null) {
+        vigente = vig.toString() == '1';
+      }
+      estado = vigente ? 'active' : 'inactive';
+    }
+    return SubscriptionInfo(
+      estado: estado,
+      trialEndsAt: json['trial_ends_at'] as String?,
+      nextRenewalAt: json['next_renewal_at'] as String?,
+    );
+  }
 }

--- a/test/context_repository_test.dart
+++ b/test/context_repository_test.dart
@@ -27,39 +27,38 @@ void main() {
     expect(ctx.locales.first.empresaId, 1);
   });
 
-  test('checkSubscription interprets extended format', () async {
+  test('checkSubscription parses nested data with numeric vigente', () async {
     final dio = MockDio();
     when(() => dio.get('/v1/estado-suscripcion',
             queryParameters: {'local_id': 10})).thenAnswer((_) async => Response(
           requestOptions: RequestOptions(path: '/v1/estado-suscripcion'),
           statusCode: 200,
           data: {
-            'estado': 'active',
-            'plan': {'codigo': 'pro'},
-            'next_renewal_at': '2025-09-18'
+            'data': {
+              'vigente': 1,
+              'empresa_id': 1,
+              'local_id': 10,
+            }
           },
         ));
     final repo = ContextRepository(dio);
     final status = await repo.checkSubscription(localId: 10);
     expect(status.vigente, true);
-    expect(status.fechaFin, '2025-09-18');
   });
 
-  test('checkSubscription interprets direct format', () async {
+  test('checkSubscription handles boolean vigente', () async {
     final dio = MockDio();
     when(() => dio.get('/v1/estado-suscripcion',
             queryParameters: {'local_id': 10})).thenAnswer((_) async => Response(
           requestOptions: RequestOptions(path: '/v1/estado-suscripcion'),
           statusCode: 200,
           data: {
-            'estado': 'active',
-            'vigente': true,
-            'fecha_fin': '2025-09-18'
+            'vigente': false,
+            'estado': 'inactive',
           },
         ));
     final repo = ContextRepository(dio);
     final status = await repo.checkSubscription(localId: 10);
-    expect(status.vigente, true);
-    expect(status.fechaFin, '2025-09-18');
+    expect(status.vigente, false);
   });
 }


### PR DESCRIPTION
## Summary
- Rely on `vigente` when refreshing subscription info
- Handle nested `data` payload and numeric `vigente` values
- Extend tests for new subscription status format

## Testing
- `flutter test` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_68a4b742f5f4832f889c664f329999af