### PR TITLE
feat: add logout and change password

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -8,6 +8,7 @@ import '../../data/auth/auth_state.dart';
 import '../../data/subscription/subscription_repository.dart';
 import '../../features/_placeholders_/subscription_blocked_page.dart';
 import '../../features/auth/ui/login_page.dart';
+import '../../features/auth/ui/change_password_page.dart';
 import '../../features/dashboard/ui/dashboard_page.dart';
 import '../../features/_placeholders_/selector_local_page.dart';
 import '../../features/products/ui/products_page.dart';
@@ -45,6 +46,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/login',
         builder: (context, state) => const LoginPage(),
+      ),
+      GoRoute(
+        path: '/change-password',
+        builder: (context, state) => const ChangePasswordPage(),
       ),
       GoRoute(
         path: '/dashboard',

--- a/lib/core/ui/menu_drawer.dart
+++ b/lib/core/ui/menu_drawer.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../data/auth/auth_repository.dart';
 
 /// Drawer used across the app to navigate between available screens.
-class MenuDrawer extends StatelessWidget {
+class MenuDrawer extends ConsumerWidget {
   const MenuDrawer({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Drawer(
       child: ListView(
         children: [
@@ -30,6 +33,23 @@ class MenuDrawer extends StatelessWidget {
             leading: const Icon(Icons.shopping_cart),
             title: const Text('Productos'),
             onTap: () => context.go('/productos'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.lock),
+            title: const Text('Cambiar contraseña'),
+            onTap: () {
+              Navigator.pop(context);
+              context.go('/change-password');
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.logout),
+            title: const Text('Cerrar sesión'),
+            onTap: () async {
+              Navigator.pop(context);
+              await ref.read(authStateProvider.notifier).logout();
+              context.go('/login');
+            },
           ),
         ],
       ),

--- a/lib/data/auth/auth_repository.dart
+++ b/lib/data/auth/auth_repository.dart
@@ -121,6 +121,17 @@ class AuthRepository {
     await _storage.write(key: _expiresKey, value: expiresAt.toIso8601String());
   }
 
+  Future<void> changePassword(
+      String currentPassword, String newPassword) async {
+    final token = await getToken();
+    await _dio.post('/v1/auth/change-password',
+        data: {
+          'current_password': currentPassword,
+          'new_password': newPassword,
+        },
+        options: Options(headers: {'Authorization': 'Bearer $token'}));
+  }
+
   Future<void> logout() async {
     await _storage.delete(key: _tokenKey);
     await _storage.delete(key: _expiresKey);

--- a/lib/features/auth/controllers/change_password_controller.dart
+++ b/lib/features/auth/controllers/change_password_controller.dart
@@ -1,0 +1,46 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../data/auth/auth_repository.dart';
+
+class ChangePasswordState {
+  const ChangePasswordState({this.isLoading = false, this.error, this.success = false});
+
+  final bool isLoading;
+  final String? error;
+  final bool success;
+
+  ChangePasswordState copyWith({bool? isLoading, String? error, bool? success}) =>
+      ChangePasswordState(
+        isLoading: isLoading ?? this.isLoading,
+        error: error,
+        success: success ?? this.success,
+      );
+}
+
+final changePasswordControllerProvider =
+    StateNotifierProvider<ChangePasswordController, ChangePasswordState>((ref) {
+  final repo = ref.read(authRepositoryProvider);
+  return ChangePasswordController(repo);
+});
+
+class ChangePasswordController extends StateNotifier<ChangePasswordState> {
+  ChangePasswordController(this._repo) : super(const ChangePasswordState());
+
+  final AuthRepository _repo;
+
+  Future<void> submit(String currentPassword, String newPassword) async {
+    if (state.isLoading) return;
+    state = state.copyWith(isLoading: true, error: null, success: false);
+    try {
+      await _repo.changePassword(currentPassword, newPassword);
+      state = state.copyWith(success: true);
+    } on DioException catch (e) {
+      state = state.copyWith(error: e.response?.data['message'] as String? ?? 'Ocurrió un problema');
+    } catch (_) {
+      state = state.copyWith(error: 'Ocurrió un problema');
+    } finally {
+      state = state.copyWith(isLoading: false);
+    }
+  }
+}

--- a/lib/features/auth/ui/change_password_page.dart
+++ b/lib/features/auth/ui/change_password_page.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_spacing.dart';
+import '../../../core/theme/app_radius.dart';
+import '../controllers/change_password_controller.dart';
+
+class ChangePasswordPage extends HookConsumerWidget {
+  const ChangePasswordPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final radius = Theme.of(context).extension<AppRadius>()!;
+    final colors = Theme.of(context).extension<AppColors>()!;
+    final formKey = useMemoized(() => GlobalKey<FormState>());
+    final currentController = useTextEditingController();
+    final newController = useTextEditingController();
+    final confirmController = useTextEditingController();
+    final obscureCurrent = useState(true);
+    final obscureNew = useState(true);
+    final obscureConfirm = useState(true);
+    final state = ref.watch(changePasswordControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cambiar contraseña')),
+      body: Center(
+        child: SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(radius.lg),
+              ),
+              child: Padding(
+                padding: EdgeInsets.all(spacing.lg),
+                child: Form(
+                  key: formKey,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text('Actualizar contraseña',
+                          style: Theme.of(context).textTheme.titleLarge),
+                      SizedBox(height: spacing.lg),
+                      if (state.error != null) ...[
+                        Container(
+                          padding: EdgeInsets.all(spacing.sm),
+                          decoration: BoxDecoration(
+                            color: colors.error,
+                            borderRadius: BorderRadius.circular(radius.sm),
+                          ),
+                          child: Text(
+                            state.error!,
+                            style: TextStyle(color: colors.n0),
+                          ),
+                        ),
+                        SizedBox(height: spacing.md),
+                      ],
+                      if (state.success) ...[
+                        Container(
+                          padding: EdgeInsets.all(spacing.sm),
+                          decoration: BoxDecoration(
+                            color: colors.success,
+                            borderRadius: BorderRadius.circular(radius.sm),
+                          ),
+                          child: Text(
+                            'Contraseña actualizada',
+                            style: TextStyle(color: colors.n0),
+                          ),
+                        ),
+                        SizedBox(height: spacing.md),
+                      ],
+                      TextFormField(
+                        controller: currentController,
+                        obscureText: obscureCurrent.value,
+                        enabled: !state.isLoading,
+                        decoration: InputDecoration(
+                          labelText: 'Contraseña actual',
+                          suffixIcon: IconButton(
+                            onPressed: () =>
+                                obscureCurrent.value = !obscureCurrent.value,
+                            icon: Icon(obscureCurrent.value
+                                ? Icons.visibility_off
+                                : Icons.visibility),
+                          ),
+                        ),
+                        validator: (v) => (v == null || v.isEmpty)
+                            ? 'Ingresa tu contraseña actual'
+                            : null,
+                      ),
+                      SizedBox(height: spacing.md),
+                      TextFormField(
+                        controller: newController,
+                        obscureText: obscureNew.value,
+                        enabled: !state.isLoading,
+                        decoration: InputDecoration(
+                          labelText: 'Nueva contraseña',
+                          suffixIcon: IconButton(
+                            onPressed: () =>
+                                obscureNew.value = !obscureNew.value,
+                            icon: Icon(obscureNew.value
+                                ? Icons.visibility_off
+                                : Icons.visibility),
+                          ),
+                        ),
+                        validator: (v) {
+                          final pass = v ?? '';
+                          if (pass.length < 8) {
+                            return 'Mínimo 8 caracteres';
+                          }
+                          return null;
+                        },
+                      ),
+                      SizedBox(height: spacing.md),
+                      TextFormField(
+                        controller: confirmController,
+                        obscureText: obscureConfirm.value,
+                        enabled: !state.isLoading,
+                        decoration: InputDecoration(
+                          labelText: 'Confirmar contraseña',
+                          suffixIcon: IconButton(
+                            onPressed: () => obscureConfirm.value =
+                                !obscureConfirm.value,
+                            icon: Icon(obscureConfirm.value
+                                ? Icons.visibility_off
+                                : Icons.visibility),
+                          ),
+                        ),
+                        validator: (v) {
+                          if (v != newController.text) {
+                            return 'Las contraseñas no coinciden';
+                          }
+                          return null;
+                        },
+                      ),
+                      SizedBox(height: spacing.lg),
+                      ElevatedButton(
+                        onPressed: state.isLoading
+                            ? null
+                            : () async {
+                                if (formKey.currentState!.validate()) {
+                                  await ref
+                                      .read(changePasswordControllerProvider
+                                          .notifier)
+                                      .submit(currentController.text,
+                                          newController.text);
+                                }
+                              },
+                        child: state.isLoading
+                            ? SizedBox(
+                                width: spacing.lg,
+                                height: spacing.lg,
+                                child: const CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Guardar'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow users to update their password via new form and API call
- add drawer entries for changing password and logging out
- expose change password endpoint in auth repository and router

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d1fa7910832fbfe9eaa5e90336af