### PR TITLE
Delay bodega loading until after widget build

### DIFF
--- a/lib/features/inventory/adjust/ui/adjust_page.dart
+++ b/lib/features/inventory/adjust/ui/adjust_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -21,7 +23,8 @@ class AdjustPage extends HookConsumerWidget {
     final motivoCtrl = useTextEditingController();
 
     useEffect(() {
-      ref.read(bodegasControllerProvider.notifier).load();
+      Future.microtask(
+          () => ref.read(bodegasControllerProvider.notifier).load());
       return null;
     }, const []);
 

--- a/lib/features/inventory/bodegas/ui/bodegas_page.dart
+++ b/lib/features/inventory/bodegas/ui/bodegas_page.dart
@@ -20,7 +20,8 @@ class BodegasPage extends HookConsumerWidget {
     final debounce = useRef<Timer?>(null);
 
     useEffect(() {
-      ref.read(bodegasControllerProvider.notifier).load();
+      Future.microtask(
+          () => ref.read(bodegasControllerProvider.notifier).load());
       return null;
     }, const []);
 

--- a/lib/features/inventory/stock/ui/stock_page.dart
+++ b/lib/features/inventory/stock/ui/stock_page.dart
@@ -26,7 +26,8 @@ class StockPage extends HookConsumerWidget {
     final debounce = useRef<Timer?>(null);
 
     useEffect(() {
-      ref.read(bodegasControllerProvider.notifier).load();
+      Future.microtask(
+          () => ref.read(bodegasControllerProvider.notifier).load());
       return null;
     }, const []);
 

--- a/lib/features/inventory/transfer/ui/transfer_page.dart
+++ b/lib/features/inventory/transfer/ui/transfer_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -20,7 +22,8 @@ class TransferPage extends HookConsumerWidget {
     final destino = useState<Bodega?>(null);
 
     useEffect(() {
-      ref.read(bodegasControllerProvider.notifier).load();
+      Future.microtask(
+          () => ref.read(bodegasControllerProvider.notifier).load());
       return null;
     }, const []);
 


### PR DESCRIPTION
## Summary
- ensure bodegas data loads asynchronously after build to avoid Riverpod build-time updates

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d2834c40832f8dd77d0b2da44def