### PR TITLE
feat: add order taking screen

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -16,6 +16,7 @@ import '../../features/invoices/ui/invoice_detail_page.dart';
 import '../../features/inventory/ui/inventory_page.dart';
 import '../../features/inventory/movements/ui/movements_page.dart';
 import '../../features/quotes/ui/quote_form_page.dart';
+import '../../features/orders/ui/order_page.dart';
 
 class GoRouterRefreshStream extends ChangeNotifier {
   GoRouterRefreshStream(Stream<dynamic> stream) {
@@ -70,6 +71,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/productos',
         builder: (context, state) => const ProductsPage(),
+      ),
+      GoRoute(
+        path: '/pedidos/nuevo',
+        builder: (context, state) => const OrderPage(),
       ),
       GoRoute(
         path: '/ventas/nueva',

--- a/lib/core/ui/menu_drawer.dart
+++ b/lib/core/ui/menu_drawer.dart
@@ -30,6 +30,11 @@ class MenuDrawer extends ConsumerWidget {
             onTap: () => context.go('/inventario/movimientos'),
           ),
           ListTile(
+            leading: const Icon(Icons.receipt_long),
+            title: const Text('Tomar pedido'),
+            onTap: () => context.go('/pedidos/nuevo'),
+          ),
+          ListTile(
             leading: const Icon(Icons.shopping_cart),
             title: const Text('Productos'),
             onTap: () => context.go('/productos'),

--- a/lib/features/orders/controllers/order_controller.dart
+++ b/lib/features/orders/controllers/order_controller.dart
@@ -1,0 +1,58 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../data/menu_repository.dart';
+import '../data/models/menu_item.dart';
+import 'order_state.dart';
+
+final orderControllerProvider =
+    StateNotifierProvider<OrderController, OrderState>((ref) {
+  return OrderController(ref);
+});
+
+class OrderController extends StateNotifier<OrderState> {
+  OrderController(this._ref) : super(const OrderState());
+
+  final Ref _ref;
+
+  Future<void> loadMenu({int localId = 100}) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final repo = _ref.read(menuRepositoryProvider);
+      final items = await repo.list(localId: localId);
+      state = state.copyWith(menu: items);
+    } catch (_) {
+      state = state.copyWith(error: 'No se pudo cargar el menú');
+    } finally {
+      state = state.copyWith(isLoading: false);
+    }
+  }
+
+  void add(MenuItem item) {
+    final idx = state.items.indexWhere((e) => e.item.id == item.id);
+    if (idx == -1) {
+      state = state.copyWith(items: [...state.items, OrderLine(item: item)]);
+    } else {
+      final list = [...state.items];
+      final line = list[idx];
+      list[idx] = line.copyWith(quantity: line.quantity + 1);
+      state = state.copyWith(items: list);
+    }
+  }
+
+  void remove(MenuItem item) {
+    final idx = state.items.indexWhere((e) => e.item.id == item.id);
+    if (idx == -1) return;
+    final list = [...state.items];
+    final line = list[idx];
+    if (line.quantity <= 1) {
+      list.removeAt(idx);
+    } else {
+      list[idx] = line.copyWith(quantity: line.quantity - 1);
+    }
+    state = state.copyWith(items: list);
+  }
+
+  void clear() {
+    state = state.copyWith(items: []);
+  }
+}

--- a/lib/features/orders/controllers/order_state.dart
+++ b/lib/features/orders/controllers/order_state.dart
@@ -1,0 +1,45 @@
+import '../data/models/menu_item.dart';
+
+class OrderLine {
+  OrderLine({required this.item, this.quantity = 1});
+
+  final MenuItem item;
+  final int quantity;
+
+  double get lineTotal => item.precioVenta * quantity;
+
+  OrderLine copyWith({MenuItem? item, int? quantity}) => OrderLine(
+        item: item ?? this.item,
+        quantity: quantity ?? this.quantity,
+      );
+}
+
+class OrderState {
+  const OrderState({
+    this.menu = const [],
+    this.items = const [],
+    this.isLoading = false,
+    this.error,
+  });
+
+  final List<MenuItem> menu;
+  final List<OrderLine> items;
+  final bool isLoading;
+  final String? error;
+
+  double get total =>
+      items.fold(0, (previous, e) => previous + e.lineTotal);
+
+  OrderState copyWith({
+    List<MenuItem>? menu,
+    List<OrderLine>? items,
+    bool? isLoading,
+    String? error,
+  }) =>
+      OrderState(
+        menu: menu ?? this.menu,
+        items: items ?? this.items,
+        isLoading: isLoading ?? this.isLoading,
+        error: error,
+      );
+}

--- a/lib/features/orders/data/menu_repository.dart
+++ b/lib/features/orders/data/menu_repository.dart
@@ -1,0 +1,31 @@
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/network/dio_client.dart';
+import 'models/menu_item.dart';
+
+final menuRepositoryProvider = Provider<MenuRepository>((ref) {
+  final dio = ref.read(dioProvider);
+  return MenuRepository(dio);
+});
+
+class MenuRepository {
+  MenuRepository(this._dio);
+
+  final Dio _dio;
+
+  Future<List<MenuItem>> list({required int localId}) async {
+    final resp =
+        await _dio.get('/v1/menu', queryParameters: {'local_id': localId});
+    final data = resp.data;
+    if (data is List) {
+      return data
+          .map((e) => MenuItem.fromJson(Map<String, dynamic>.from(e)))
+          .toList();
+    }
+    final list = data['data'] as List<dynamic>;
+    return list
+        .map((e) => MenuItem.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+}

--- a/lib/features/orders/data/models/menu_item.dart
+++ b/lib/features/orders/data/models/menu_item.dart
@@ -1,0 +1,84 @@
+class MenuItem {
+  MenuItem({
+    required this.id,
+    required this.codigo,
+    required this.nombre,
+    this.descripcion,
+    required this.tipo,
+    required this.precioVenta,
+    required this.impuestoId,
+    required this.categoriaNombre,
+    required this.impuestoCodigo,
+    required this.impuestoPorcentaje,
+    required this.stockLocal,
+  });
+
+  final int id;
+  final String codigo;
+  final String nombre;
+  final String? descripcion;
+  final String tipo;
+  final double precioVenta;
+  final int impuestoId;
+  final String categoriaNombre;
+  final String impuestoCodigo;
+  final double impuestoPorcentaje;
+  final double stockLocal;
+
+  factory MenuItem.fromJson(Map<String, dynamic> json) => MenuItem(
+        id: json['id'] as int,
+        codigo: json['codigo'] as String,
+        nombre: json['nombre'] as String,
+        descripcion: json['descripcion'] as String?,
+        tipo: json['tipo'] as String,
+        precioVenta: (json['precio_venta'] as num).toDouble(),
+        impuestoId: json['impuesto_id'] as int,
+        categoriaNombre: json['categoria_nombre'] as String,
+        impuestoCodigo: json['impuesto_codigo'] as String,
+        impuestoPorcentaje:
+            (double.tryParse(json['impuesto_porcentaje'].toString()) ?? 0),
+        stockLocal: (double.tryParse(json['stock_local'].toString()) ?? 0),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'codigo': codigo,
+        'nombre': nombre,
+        'descripcion': descripcion,
+        'tipo': tipo,
+        'precio_venta': precioVenta,
+        'impuesto_id': impuestoId,
+        'categoria_nombre': categoriaNombre,
+        'impuesto_codigo': impuestoCodigo,
+        'impuesto_porcentaje': impuestoPorcentaje,
+        'stock_local': stockLocal,
+      };
+
+  MenuItem copyWith({
+    int? id,
+    String? codigo,
+    String? nombre,
+    String? descripcion,
+    String? tipo,
+    double? precioVenta,
+    int? impuestoId,
+    String? categoriaNombre,
+    String? impuestoCodigo,
+    double? impuestoPorcentaje,
+    double? stockLocal,
+  }) {
+    return MenuItem(
+      id: id ?? this.id,
+      codigo: codigo ?? this.codigo,
+      nombre: nombre ?? this.nombre,
+      descripcion: descripcion ?? this.descripcion,
+      tipo: tipo ?? this.tipo,
+      precioVenta: precioVenta ?? this.precioVenta,
+      impuestoId: impuestoId ?? this.impuestoId,
+      categoriaNombre: categoriaNombre ?? this.categoriaNombre,
+      impuestoCodigo: impuestoCodigo ?? this.impuestoCodigo,
+      impuestoPorcentaje: impuestoPorcentaje ?? this.impuestoPorcentaje,
+      stockLocal: stockLocal ?? this.stockLocal,
+    );
+  }
+}

--- a/lib/features/orders/ui/order_page.dart
+++ b/lib/features/orders/ui/order_page.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/ui/menu_drawer.dart';
+import '../controllers/order_controller.dart';
+
+class OrderPage extends HookConsumerWidget {
+  const OrderPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(orderControllerProvider);
+
+    useEffect(() {
+      ref.read(orderControllerProvider.notifier).loadMenu();
+      return null;
+    }, const []);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tomar pedido')),
+      drawer: const MenuDrawer(),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Row(
+              children: [
+                Expanded(
+                  child: GridView.builder(
+                    padding: const EdgeInsets.all(8),
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      childAspectRatio: 3 / 2,
+                      crossAxisSpacing: 8,
+                      mainAxisSpacing: 8,
+                    ),
+                    itemCount: state.menu.length,
+                    itemBuilder: (context, index) {
+                      final item = state.menu[index];
+                      return Card(
+                        child: InkWell(
+                          onTap: () => ref
+                              .read(orderControllerProvider.notifier)
+                              .add(item),
+                          child: Padding(
+                            padding: const EdgeInsets.all(8),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(item.nombre,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium),
+                                const Spacer(),
+                                Text('\$${item.precioVenta.toStringAsFixed(2)}'),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                Container(
+                  width: 300,
+                  color: Colors.grey.shade200,
+                  child: Column(
+                    children: [
+                      const ListTile(title: Text('Pedido')),
+                      Expanded(
+                        child: ListView.builder(
+                          itemCount: state.items.length,
+                          itemBuilder: (context, index) {
+                            final line = state.items[index];
+                            return ListTile(
+                              title: Text(line.item.nombre),
+                              subtitle: Text(
+                                  '${line.quantity} x \$${line.item.precioVenta.toStringAsFixed(2)}'),
+                              trailing: Text(
+                                  '\$${(line.item.precioVenta * line.quantity).toStringAsFixed(2)}'),
+                            );
+                          },
+                        ),
+                      ),
+                      const Divider(height: 1),
+                      Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: Row(
+                          children: [
+                            const Expanded(
+                              child: Text('Total',
+                                  style: TextStyle(
+                                      fontWeight: FontWeight.bold)),
+                            ),
+                            Text(
+                              '\$${state.total.toStringAsFixed(2)}',
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement menu item model and repository
- add controller and UI to take orders
- wire new order page into router and menu drawer

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a510d79a04832f9e1c4bb07f9e05d2