### PR TITLE
Fix order page provider update during build

### DIFF
--- a/lib/features/orders/ui/order_page.dart
+++ b/lib/features/orders/ui/order_page.dart
@@ -13,7 +13,8 @@ class OrderPage extends HookConsumerWidget {
     final state = ref.watch(orderControllerProvider);
 
     useEffect(() {
-      ref.read(orderControllerProvider.notifier).loadMenu();
+      Future(() =>
+          ref.read(orderControllerProvider.notifier).loadMenu());
       return null;
     }, const []);
 


### PR DESCRIPTION
## Summary
- avoid updating providers during widget build by delaying initial menu load

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a513254494832f94debbc16879a77c