### PR TITLE
fix: parse menu prices

### DIFF
--- a/lib/features/orders/data/models/menu_item.dart
+++ b/lib/features/orders/data/models/menu_item.dart
@@ -31,7 +31,8 @@ class MenuItem {
         nombre: json['nombre'] as String,
         descripcion: json['descripcion'] as String?,
         tipo: json['tipo'] as String,
-        precioVenta: (json['precio_venta'] as num).toDouble(),
+        precioVenta:
+            (double.tryParse(json['precio_venta'].toString()) ?? 0),
         impuestoId: json['impuesto_id'] as int,
         categoriaNombre: json['categoria_nombre'] as String,
         impuestoCodigo: json['impuesto_codigo'] as String,

--- a/test/menu_item_test.dart
+++ b/test/menu_item_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:punto_venta_front/features/orders/data/models/menu_item.dart';
+
+void main() {
+  test('parses menu item json with numeric strings', () {
+    final item = MenuItem.fromJson({
+      'id': 501,
+      'codigo': 'BUR-CLAS',
+      'nombre': 'Hamburguesa Clásica',
+      'descripcion': '200g carne',
+      'tipo': 'BIEN',
+      'precio_venta': '5.50',
+      'impuesto_id': 1,
+      'categoria_nombre': 'Hamburguesas',
+      'impuesto_codigo': 'IVA12',
+      'impuesto_porcentaje': '15.000',
+      'stock_local': '0.0000',
+    });
+    expect(item.id, 501);
+    expect(item.precioVenta, 5.50);
+    expect(item.impuestoPorcentaje, 15);
+    expect(item.stockLocal, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- parse menu item prices that arrive as strings
- add unit test for menu item JSON parsing

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a5156e50c8832f9ead84023a5a6730