### PR TITLE
Show images for menu items

### DIFF
--- a/lib/features/orders/data/models/menu_item.dart
+++ b/lib/features/orders/data/models/menu_item.dart
@@ -11,6 +11,7 @@ class MenuItem {
     required this.impuestoCodigo,
     required this.impuestoPorcentaje,
     required this.stockLocal,
+    this.urlImagen,
   });
 
   final int id;
@@ -24,6 +25,7 @@ class MenuItem {
   final String impuestoCodigo;
   final double impuestoPorcentaje;
   final double stockLocal;
+  final String? urlImagen;
 
   factory MenuItem.fromJson(Map<String, dynamic> json) => MenuItem(
         id: json['id'] as int,
@@ -39,6 +41,7 @@ class MenuItem {
         impuestoPorcentaje:
             (double.tryParse(json['impuesto_porcentaje'].toString()) ?? 0),
         stockLocal: (double.tryParse(json['stock_local'].toString()) ?? 0),
+        urlImagen: json['url_imagen'] as String?,
       );
 
   Map<String, dynamic> toJson() => {
@@ -53,6 +56,7 @@ class MenuItem {
         'impuesto_codigo': impuestoCodigo,
         'impuesto_porcentaje': impuestoPorcentaje,
         'stock_local': stockLocal,
+        'url_imagen': urlImagen,
       };
 
   MenuItem copyWith({
@@ -67,6 +71,7 @@ class MenuItem {
     String? impuestoCodigo,
     double? impuestoPorcentaje,
     double? stockLocal,
+    String? urlImagen,
   }) {
     return MenuItem(
       id: id ?? this.id,
@@ -80,6 +85,7 @@ class MenuItem {
       impuestoCodigo: impuestoCodigo ?? this.impuestoCodigo,
       impuestoPorcentaje: impuestoPorcentaje ?? this.impuestoPorcentaje,
       stockLocal: stockLocal ?? this.stockLocal,
+      urlImagen: urlImagen ?? this.urlImagen,
     );
   }
 }

--- a/lib/features/orders/ui/order_page.dart
+++ b/lib/features/orders/ui/order_page.dart
@@ -47,12 +47,24 @@ class OrderPage extends HookConsumerWidget {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Text(item.nombre,
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .titleMedium),
+                                if (item.urlImagen != null) ...[
+                                  Expanded(
+                                    child: Image.network(
+                                      item.urlImagen!,
+                                      fit: BoxFit.cover,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 8),
+                                ],
+                                Text(
+                                  item.nombre,
+                                  style:
+                                      Theme.of(context).textTheme.titleMedium,
+                                ),
                                 const Spacer(),
-                                Text('\$${item.precioVenta.toStringAsFixed(2)}'),
+                                Text(
+                                  '\$${item.precioVenta.toStringAsFixed(2)}',
+                                ),
                               ],
                             ),
                           ),


### PR DESCRIPTION
## Summary
- parse `url_imagen` in `MenuItem` model
- render menu item network images on order page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51db1c854832faf5fdbe14aacd80f